### PR TITLE
Compute the percentage of lost packets

### DIFF
--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39:latest
+FROM registry.access.redhat.com/ubi8/python-311:latest
 
 ENV TREX_VER v2.85
 ENV TREX_REPO https://github.com/cisco-system-traffic-generator/trex-core.git


### PR DESCRIPTION
I've added more detailed debug information because 100% packet loss and 1% packet loss are two different scenarios. Here's how the percentage of lost packets is [displayed](https://www.distributed-ci.io/jobs/c221a1c1-d901-4d90-b0fe-50d2bc7e6a00/jobStates):
```
Packets lost from 0 to 1:   129454 packets, which is 10.787833333333333% packet loss
Packets lost from 1 to 0:   -156783 packets, which is -13.06525% packet loss
Total packets lost: -27329 packets, which is -1.1387083333333334% packet loss

Test has passed :-)
```
Before it was [like this](https://www.distributed-ci.io/jobs/2608c52a-71ab-4582-9be5-7d5aa4996b36/files):
```
packets lost from 0 --> 1:   -33362912 pkts
packets lost from 1 --> 0:   -36781561 pkts
packet lost total: -70144473 pkts

Test has passed :-)
```

All the updates in this change:

- Compute the percentage of lost packets
- Switching trex-container-app to the python-311 image
- Using f-strings in the logs of trexstats