### PR TITLE
Move operator-sdk to v1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DIRS            := testpmd-container-app trex-container-app cnf-app-mac-operator testpmd-lb-operator testpmd-operator trex-operator nfv-example-cnf-index
 
-OPERATOR_SDK_VER:= 1.31.0
+OPERATOR_SDK_VER:= 1.32.0
 
 # Print the possible targets and a short description
 .PHONY: targets

--- a/cnf-app-mac-operator/CHANGELOG.md
+++ b/cnf-app-mac-operator/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.11] - 2023-12-04
+
+- Updated OperatorSDK to v1.32.0
+
+## [0.2.10] - 2023-06-02
+
+- Updates required for PR/PUSH Github actions
+
 ## [0.2.9] - 2021-08-25
 
 - No changes, just aligning all other operators (testpmd, testpmd-lb, trex)

--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -1,7 +1,7 @@
 SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
-VERSION          := 0.2.10
+VERSION          := 0.2.11
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -9,7 +9,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := cnf-app-mac-operator
-OPERATOR_SDK_VER ?= 1.31.0
+OPERATOR_SDK_VER ?= 1.32.0
 CONTROLLER_VER   := 0.4.1
 KUSTOMIZE_VER    := 3.8.7
 OS               = $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/testpmd-lb-operator/CHANGELOG.md
+++ b/testpmd-lb-operator/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.11] - 2023-12-04
+
+- Updated OperatorSDK to v1.32.0
+- Updated ansible requirements
+  - operator_sdk.util 0.5.0
+
+## [0.2.10] - 2023-06-02
+
+- Updates required for PR/PUSH Github actions
+
 ## [0.2.9] - 2021-08-25
 
 - Updated ansible requirements

--- a/testpmd-lb-operator/Makefile
+++ b/testpmd-lb-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.10
+VERSION          := 0.2.11
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-lb-operator
-OPERATOR_SDK_VER ?= 1.31.0
+OPERATOR_SDK_VER ?= 1.32.0
 KUSTOMIZE_VER    := 3.5.4
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')
 

--- a/testpmd-lb-operator/requirements.yml
+++ b/testpmd-lb-operator/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: community.kubernetes
     version: "1.2.1"
   - name: operator_sdk.util
-    version: "0.2.0"
+    version: "0.5.0"

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.11] - 2023-12-04
+
+- Updated OperatorSDK to v1.32.0
+- Updated ansible requirements
+  - operator_sdk.util 0.5.0
+
+## [0.2.10] - 2023-06-02
+
+- Updates required for PR/PUSH Github actions
+
 ## [0.2.9] - 2021-08-25
 
 - Updated application versions

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.10
+VERSION          := 0.2.11
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-operator
-OPERATOR_SDK_VER ?= 1.31.0
+OPERATOR_SDK_VER ?= 1.32.0
 KUSTOMIZE_VER    := 3.5.4
 DPDK_VER         ?= v4.6.3
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')

--- a/testpmd-operator/requirements.yml
+++ b/testpmd-operator/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: community.kubernetes
     version: "1.2.1"
   - name: operator_sdk.util
-    version: "0.2.0"
+    version: "0.5.0"

--- a/trex-operator/CHANGELOG.md
+++ b/trex-operator/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.14] - 2023-12-04
+
+- Updated OperatorSDK to v1.32.0
+- Updated ansible requirements
+  - operator_sdk.util 0.5.0
+
+## [0.2.13] - 2023-06-02
+
+- Updates required for PR/PUSH Github actions
+
 ## [0.2.12] - 2023-02-01
 
 - Moved from beta-version events.k8s.io/v1beta1 to GA events.k8s.io/v1 because of v1beta1 deprecation in OCP-4.12

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.13
+VERSION          := 0.2.14
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := trex-operator
-OPERATOR_SDK_VER ?= 1.31.0
+OPERATOR_SDK_VER ?= 1.32.0
 KUSTOMIZE_VER    := 3.5.4
 TREX_VER         ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[trex-container-app]}"')
 

--- a/trex-operator/requirements.yml
+++ b/trex-operator/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: community.kubernetes
     version: "1.2.1"
   - name: operator_sdk.util
-    version: "0.2.0"
+    version: "0.5.0"


### PR DESCRIPTION
- Update operator-sdk to v1.32.0
- Update operator_sdk.util collection to latest version, v0.5.0 (https://galaxy.ansible.com/ui/repo/published/operator_sdk/util/)
- Update CHANGELOG.md, including versions not reported in the corresponding files, following https://github.com/openshift-kni/example-cnf/pull/27 to avoid merge conflicts afterwards