### PR TITLE
Update CHANGELOG, missed in prevs changes

### DIFF
--- a/nfv-example-cnf-index/CHANGELOG.md
+++ b/nfv-example-cnf-index/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.3.4] - 2023-06-02
+
+- Updates required for PR/PUSH Github actions
+
 ## [0.3.3] - 2023-02-01
 
 - Use a new trex-operator with the v1 version of the events API


### PR DESCRIPTION
In https://github.com/openshift-kni/example-cnf/pull/26, I wanted to update the CHANGELOG to reflect the update of the requirements of some operators, but I discovered that last change in the operators, which was made in this [commit](https://github.com/openshift-kni/example-cnf/commit/03a231d53529feb32e974525022a0227147ac35b#diff-e3612775a276e279cd69e1faccd661f0757c220ff155b5c6e023ba8cd8c110f3), didn't make the proper update in the CHANGELOG files. Doing it here to have them properly updated. Also adding the file in the operators where it's not currently present, directly pointing to the latest.