### PR TITLE
Add OCP 4.16 component

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -68,7 +68,8 @@ jobs:
           OCP-4.12,
           OCP-4.13,
           OCP-4.14,
-          OCP-4.15
+          OCP-4.15,
+          OCP-4.16
           '
           componentName: nfv-example-cnf-index
           componentVersion: v${{ needs.build_all.outputs.version }}


### PR DESCRIPTION
example-cnf is not launched in OCP 4.16 daily jobs because we missed the creation of the corresponding component.