### PR TITLE
Move operator-sdk to v1.33.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DIRS            := testpmd-container-app trex-container-app cnf-app-mac-operator testpmd-lb-operator testpmd-operator trex-operator nfv-example-cnf-index
 
-OPERATOR_SDK_VER:= 1.32.0
+OPERATOR_SDK_VER:= 1.33.0
 
 # Print the possible targets and a short description
 .PHONY: targets

--- a/cnf-app-mac-operator/CHANGELOG.md
+++ b/cnf-app-mac-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.12] - 2023-12-21
+
+- Updated OperatorSDK to v1.33.0
+
 ## [0.2.11] - 2023-12-04
 
 - Updated OperatorSDK to v1.32.0

--- a/cnf-app-mac-operator/CHANGELOG.md
+++ b/cnf-app-mac-operator/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
-## [0.2.12] - 2023-12-21
+## [0.2.12] - 2023-12-22
 
 - Updated OperatorSDK to v1.33.0
+- Updated Kustomize to v5.0.1
 
 ## [0.2.11] - 2023-12-04
 

--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -1,7 +1,7 @@
 SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
-VERSION          := 0.2.11
+VERSION          := 0.2.12
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -9,7 +9,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := cnf-app-mac-operator
-OPERATOR_SDK_VER ?= 1.32.0
+OPERATOR_SDK_VER ?= 1.33.0
 CONTROLLER_VER   := 0.4.1
 KUSTOMIZE_VER    := 3.8.7
 OS               = $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -11,7 +11,7 @@ CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := cnf-app-mac-operator
 OPERATOR_SDK_VER ?= 1.33.0
 CONTROLLER_VER   := 0.4.1
-KUSTOMIZE_VER    := 3.8.7
+KUSTOMIZE_VER    := 5.0.1
 OS               = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH             = $(shell uname -m | sed 's/x86_64/amd64/')
 

--- a/testpmd-lb-operator/CHANGELOG.md
+++ b/testpmd-lb-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.12] - 2023-12-21
+
+- Updated OperatorSDK to v1.33.0
+
 ## [0.2.11] - 2023-12-04
 
 - Updated OperatorSDK to v1.32.0

--- a/testpmd-lb-operator/CHANGELOG.md
+++ b/testpmd-lb-operator/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
-## [0.2.12] - 2023-12-21
+## [0.2.12] - 2023-12-22
 
 - Updated OperatorSDK to v1.33.0
+- Updated Kustomize to v5.0.1
 
 ## [0.2.11] - 2023-12-04
 

--- a/testpmd-lb-operator/Makefile
+++ b/testpmd-lb-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.11
+VERSION          := 0.2.12
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-lb-operator
-OPERATOR_SDK_VER ?= 1.32.0
+OPERATOR_SDK_VER ?= 1.33.0
 KUSTOMIZE_VER    := 3.5.4
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')
 

--- a/testpmd-lb-operator/Makefile
+++ b/testpmd-lb-operator/Makefile
@@ -11,7 +11,7 @@ CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-lb-operator
 OPERATOR_SDK_VER ?= 1.33.0
-KUSTOMIZE_VER    := 3.5.4
+KUSTOMIZE_VER    := 5.0.1
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')
 
 # Default bundle image tag

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.12] - 2023-12-21
+
+- Updated OperatorSDK to v1.33.0
+
 ## [0.2.11] - 2023-12-04
 
 - Updated OperatorSDK to v1.32.0

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
-## [0.2.12] - 2023-12-21
+## [0.2.12] - 2023-12-22
 
 - Updated OperatorSDK to v1.33.0
+- Updated Kustomize to v5.0.1
 
 ## [0.2.11] - 2023-12-04
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -11,7 +11,7 @@ CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-operator
 OPERATOR_SDK_VER ?= 1.33.0
-KUSTOMIZE_VER    := 3.5.4
+KUSTOMIZE_VER    := 5.0.1
 # TESTPMD_VER determines the DPDK version to use
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.11
+VERSION          := 0.2.12
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := testpmd-operator
-OPERATOR_SDK_VER ?= 1.32.0
+OPERATOR_SDK_VER ?= 1.33.0
 KUSTOMIZE_VER    := 3.5.4
 # TESTPMD_VER determines the DPDK version to use
 TESTPMD_VER      ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')

--- a/trex-operator/CHANGELOG.md
+++ b/trex-operator/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
-## [0.2.15] - 2023-12-21
+## [0.2.15] - 2023-12-22
 
 - Updated OperatorSDK to v1.33.0
+- Updated Kustomize to v5.0.1
 
 ## [0.2.14] - 2023-12-04
 

--- a/trex-operator/CHANGELOG.md
+++ b/trex-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.15] - 2023-12-21
+
+- Updated OperatorSDK to v1.33.0
+
 ## [0.2.14] - 2023-12-04
 
 - Updated OperatorSDK to v1.32.0

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -11,7 +11,7 @@ CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := trex-operator
 OPERATOR_SDK_VER ?= 1.33.0
-KUSTOMIZE_VER    := 3.5.4
+KUSTOMIZE_VER    := 5.0.1
 TREX_VER         ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[trex-container-app]}"')
 
 # Default bundle image tag

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -2,7 +2,7 @@ SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
 # Current Operator version
-VERSION          := 0.2.14
+VERSION          := 0.2.15
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int
@@ -10,7 +10,7 @@ DEFAULT_CHANNEL  ?= alpha
 CONTAINER_CLI    ?= podman
 CLUSTER_CLI      ?= oc
 OPERATOR_NAME    := trex-operator
-OPERATOR_SDK_VER ?= 1.32.0
+OPERATOR_SDK_VER ?= 1.33.0
 KUSTOMIZE_VER    := 3.5.4
 TREX_VER         ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[trex-container-app]}"')
 


### PR DESCRIPTION
Consequently, also bump kustomize version to the version used by operator-sdk v1.33.0, as shown in this PR