### PR TITLE
Implement webserver in cnf-app-mac-operator to handle lifecycle and probe requests

### DIFF
--- a/cnf-app-mac-operator/CHANGELOG.md
+++ b/cnf-app-mac-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.13] - 2024-01-05
+
+- Implement webserver to handle lifecycle and probe requests
+
 ## [0.2.12] - 2023-12-22
 
 - Updated OperatorSDK to v1.33.0

--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -1,7 +1,7 @@
 SHELL            := /bin/bash
 DATE             ?= $(shell date --utc +%Y%m%d%H%M)
 SHA              ?= $(shell git rev-parse --short HEAD)
-VERSION          := 0.2.12
+VERSION          := 0.2.13
 TAG              := $(VERSION)-$(DATE).$(SHA)
 REGISTRY         ?= quay.io
 ORG              ?= rh-nfv-int

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -35,5 +35,34 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # lifecycle admits not only `exec`, but also `httpGet`:
+        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /poststartz
+              port: 8095
+          preStop:
+            httpGet:
+              path: /prestopz
+              port: 8095
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8095
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8095
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /startz
+            port: 8095
+          initialDelaySeconds: 5
+          periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -105,8 +105,9 @@ func getWatchNamespace() (string, error) {
 }
 
 func main() {
-	// Start calling the webserver
-	setLifecycleWebServer()
+	// Start calling the webserver as a goroutine to make it asynchronously, so that it does not affect
+	// to the rest of the execution
+	go setLifecycleWebServer()
 
 	var metricsAddr string
 	var enableLeaderElection bool

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +46,50 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func setLifecycleWebServer() {
+	setupLog.Info("configure webserver")
+
+	// Liveness Probe handler
+	http.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Println("query received to check liveness")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+	// Readiness Probe handler
+	http.HandleFunc("/readyz", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Println("query received to check readiness")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+	// Startup Probe handler
+	http.HandleFunc("/startz", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Println("query received to check startup")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+
+	// Lifecycle postStart handler
+	http.HandleFunc("/poststartz", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Println("query received to check postStart")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+	// Lifecycle preStop handler
+	http.HandleFunc("/prestopz", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Println("query received to check preStop")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+
+	setupLog.Info("try to start webserver")
+	// Launch web server on port 8095
+	err := http.ListenAndServe(":8095", nil)
+	if err != nil {
+		setupLog.Error(err, "unable to start webserver")
+		os.Exit(1)
+	}
+}
+
 // getWatchNamespace returns the Namespace the operator should be watching for changes
 func getWatchNamespace() (string, error) {
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
@@ -60,6 +105,9 @@ func getWatchNamespace() (string, error) {
 }
 
 func main() {
+	// Start calling the webserver
+	setLifecycleWebServer()
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
build-depends: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/44

Lifecycle hooks can be implemented with a `httpGet` resource, we don't really need to use a shell command for that: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations

To make it available in cnf-app-mac-operator, I've added a webserver in the main application to handle these requests, and also for all lifecycle probes (readiness, liveness and startup).

With all this, example-cnf should continue working fine and, now, all these tests should be passing for cnf-app-mac-operator:

lifecycle-container-shutdown
lifecycle-container-startup
lifecycle-liveness-probe
lifecycle-readiness-probe
lifecycle-startup-probe

(Adding https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/44 as dependency just to avoid issues found in daily jobs with this case).