### PR TITLE
Fix for cnf-app-mac-operator to pass later installation

### DIFF
--- a/cnf-app-mac-operator/Dockerfile
+++ b/cnf-app-mac-operator/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:debug-nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -35,23 +35,30 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8095
-            initialDelaySeconds: 15
-            periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8095
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        startupProbe:
-          httpGet:
-            path: /startz
-            port: 8095
-          initialDelaySeconds: 30
-          periodSeconds: 20
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/busybox/sh", "-c", "echo Hello from the postStart handler"]
+          preStop:
+            exec:
+              command: ["/busybox/sh", "-c", "echo Hello from the preStop handler"]
+#        livenessProbe:
+#          httpGet:
+#            path: /healthz
+#            port: 8095
+#          initialDelaySeconds: 5
+#          periodSeconds: 10
+#        readinessProbe:
+#          httpGet:
+#            path: /readyz
+#            port: 8095
+#          initialDelaySeconds: 5
+#          periodSeconds: 10
+#        startupProbe:
+#          httpGet:
+#            path: /startz
+#            port: 8095
+#          initialDelaySeconds: 5
+#          periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -42,23 +42,23 @@ spec:
           preStop:
             exec:
               command: ["/busybox/sh", "-c", "echo Hello from the preStop handler"]
-#        livenessProbe:
-#          httpGet:
-#            path: /healthz
-#            port: 8095
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
-#        readinessProbe:
-#          httpGet:
-#            path: /readyz
-#            port: 8095
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
-#        startupProbe:
-#          httpGet:
-#            path: /startz
-#            port: 8095
-#          initialDelaySeconds: 5
-#          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8095
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8095
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /startz
+            port: 8095
+          initialDelaySeconds: 30
+          periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -35,17 +35,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # lifecycle admits not only `exec`, but also `httpGet`:
-        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations
-        lifecycle:
-          postStart:
-            httpGet:
-              path: /poststartz
-              port: 8095
-          preStop:
-            httpGet:
-              path: /prestopz
-              port: 8095
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -35,12 +35,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # lifecycle admits not only `exec`, but also `httpGet`:
+        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /poststartz
+              port: 8095
+          preStop:
+            httpGet:
+              path: /prestopz
+              port: 8095
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8095
-          initialDelaySeconds: 5
-          periodSeconds: 10
+            initialDelaySeconds: 15
+            periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
@@ -51,7 +62,7 @@ spec:
           httpGet:
             path: /startz
             port: 8095
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 30
+          periodSeconds: 20
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -106,11 +106,9 @@ func waitUntilLifecycleWebServerIsReady() {
 			setupLog.Error(err, "error making http request")
 			os.Exit(1)
 		}
-		else {
-			if res.StatusCode == http.StatusOK {
-				setupLog.Info("webserver is ready")
-				break
-			}
+		if res.StatusCode == http.StatusOK {
+			setupLog.Info("webserver is ready")
+			break
 		}
 	}
 }

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -73,6 +73,19 @@ func setLifecycleWebServer() {
 		rw.Write([]byte("ok"))
 	})
 
+	// Lifecycle postStart handler
+	http.HandleFunc("/poststartz", func(rw http.ResponseWriter, r *http.Request) {
+		setupLog.Info("query received to check postStart")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+	// Lifecycle preStop handler
+	http.HandleFunc("/prestopz", func(rw http.ResponseWriter, r *http.Request) {
+		setupLog.Info("query received to check preStop")
+		rw.WriteHeader(200)
+		rw.Write([]byte("ok"))
+	})
+
 	setupLog.Info("try to start webserver")
 	// Launch web server on port 8095
 	err := http.ListenAndServe(":8095", nil)

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -73,19 +73,6 @@ func setLifecycleWebServer() {
 		rw.Write([]byte("ok"))
 	})
 
-	// Lifecycle postStart handler
-	http.HandleFunc("/poststartz", func(rw http.ResponseWriter, r *http.Request) {
-		setupLog.Info("query received to check postStart")
-		rw.WriteHeader(200)
-		rw.Write([]byte("ok"))
-	})
-	// Lifecycle preStop handler
-	http.HandleFunc("/prestopz", func(rw http.ResponseWriter, r *http.Request) {
-		setupLog.Info("query received to check preStop")
-		rw.WriteHeader(200)
-		rw.Write([]byte("ok"))
-	})
-
 	setupLog.Info("try to start webserver")
 	// Launch web server on port 8095
 	err := http.ListenAndServe(":8095", nil)

--- a/cnf-app-mac-operator/main.go
+++ b/cnf-app-mac-operator/main.go
@@ -87,8 +87,8 @@ func waitUntilLifecycleWebServerIsReady() {
 		// Each retry will be made after 100 ms
 		time.Sleep(100 * time.Millisecond)
 
-		// Check liveness probe for this case
-		res, err := http.Get("http://localhost:8080/health")
+		// Check startup probe for this case
+		res, err := http.Get("http://localhost:8095/startz")
 		if err != nil {
 			setupLog.Error(err, "error making http request")
 			os.Exit(1)


### PR DESCRIPTION
This intends to fix CILAB-443

- According to [k8s docs](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) regarding postStart hook: _This hook is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. No parameters are passed to the handler._ In that case, since we need to have to execute the ENTRYPOINT to make sure the application is running, so that the webserver is available, it's not guaranteed that the webserver is ready by the time the postStart handler is triggered. Also, if we take a look to [OCP API for pods](https://docs.openshift.com/container-platform/4.14/rest_api/workloads_apis/pod-v1.html), there's no way to configure a delay or something similar to what we do in liveness/readiness/startup probes.
- Agreed on daily meetings to use shell in cnf-app-mac-operator, which will be needed for the UBI check in tnf. So, now, we can use commands for postStart and preStop hooks, avoiding the previous issue.
- Including retries till webserver is working for liveness/readiness/startup probes.
- Extending the time to wait for startup probe, which is the first one to be executed.
- Changing prints to logs.