### PR TITLE
Add some comments and considerations regarding the building process we make

### DIFF
--- a/testpmd-lb-operator/relatedImages.yaml.in
+++ b/testpmd-lb-operator/relatedImages.yaml.in
@@ -1,3 +1,5 @@
+# these two images are not hardcoded - they are replaced by the testpmd-lb-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/testpmd-lb-operator/Makefile - See "bundle" task
   relatedImages:
     - name: testpmd-container-app-testpmd
       image: "quay.io/rh-nfv-int/testpmd-container-app-testpmd@sha256:eca74e7cb50612e38a7712450ed123a7ed49f305b88f5e3b59d6368394535603"  # v0.2.3

--- a/testpmd-lb-operator/roles/loadbalancer/defaults/main.yml.in
+++ b/testpmd-lb-operator/roles/loadbalancer/defaults/main.yml.in
@@ -4,6 +4,8 @@ privileged: false
 network_defintions: ""
 environments: {}
 
+# these two images are not hardcoded - they are replaced by the testpmd-lb-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/testpmd-lb-operator/Makefile - See "ensure_digests" task
 image_testpmd: "quay.io/rh-nfv-int/testpmd-container-app-testpmd@sha256:eca74e7cb50612e38a7712450ed123a7ed49f305b88f5e3b59d6368394535603"  # v0.2.3
 image_listener: "quay.io/rh-nfv-int/testpmd-container-app-listener@sha256:050c5f7117bd6135af48cf742600bd30ab8448fe12fcab44960c1508c10327b1" # v0.2.3
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -66,8 +66,13 @@ deploy: kustomize
 undeploy: kustomize
 	$(KUSTOMIZE) build config/default | ${CLUSTER_CLI} delete -f -
 
+# Ensure proper digests for testpmd-container-app-mac
+ensure_digests:
+	cp roles/testpmd/defaults/main.yml.in roles/testpmd/defaults/main.yml
+	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-mac:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$DIGEST" ] && sed -i -e "s/testpmd-container-app-mac@.*/testpmd-container-app-mac@$${DIGEST}\"   # $(TESTPMD_VER)/" roles/testpmd/defaults/main.yml
+
 # Build the operator image
-operator-build:
+operator-build: ensure_digests
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG} -t $(REL_IMG); \
 	else \

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -69,7 +69,7 @@ undeploy: kustomize
 # Ensure proper digests for testpmd-container-app-mac
 ensure_digests:
 	cp roles/testpmd/defaults/main.yml.in roles/testpmd/defaults/main.yml
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-mac:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$DIGEST" ] && sed -i -e "s/testpmd-container-app-mac@.*/testpmd-container-app-mac@$${DIGEST}\"   # $(TESTPMD_VER)/" roles/testpmd/defaults/main.yml
+	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-mac:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-mac@.*/testpmd-container-app-mac@$${DIGEST}\"   # $(TESTPMD_VER)/" roles/testpmd/defaults/main.yml
 
 # Build the operator image
 operator-build: ensure_digests
@@ -140,7 +140,7 @@ bundle: kustomize operator-sdk
 	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && [ -n "$${DIGEST}" ] && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
 	cp relatedImages.yaml.in relatedImages.yaml
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-mac:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$DIGEST" ] && sed -i -e "s/testpmd-container-app-mac@.*/testpmd-container-app-mac@$${DIGEST}\"   # $(TESTPMD_VER)/" relatedImages.yaml
+	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-mac:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-mac@.*/testpmd-container-app-mac@$${DIGEST}\"   # $(TESTPMD_VER)/" relatedImages.yaml
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/testpmd-operator/relatedImages.yaml.in
+++ b/testpmd-operator/relatedImages.yaml.in
@@ -1,5 +1,7 @@
   relatedImages:
     - name: testpmd-app
       image: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:dccbad0b74151eb62bdd1ed9a1ec2d2588acc01db7cc126981795c8315bb678b"  # v4.14
+    # this image is not hardcoded - it is replaced by the testpmd-operator Makefile launched by the Github actions defined for this repo
+    # https://github.com/openshift-kni/example-cnf/blob/main/testpmd-operator/Makefile - See "bundle" task
     - name: testpmd-container-app-mac
       image: "quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:0a516a6f646989cb1abe77696b19838ff6138f177b1e4df6970b7bc8938552df"   # v0.2.3

--- a/testpmd-operator/roles/testpmd/defaults/main.yml.in
+++ b/testpmd-operator/roles/testpmd/defaults/main.yml.in
@@ -8,6 +8,8 @@ network_defintions: ""
 network_resources: {}
 environments: {}
 image_testpmd: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:dccbad0b74151eb62bdd1ed9a1ec2d2588acc01db7cc126981795c8315bb678b"  # v4.14
+# this image is not hardcoded - it is replaced by the testpmd-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/testpmd-operator/Makefile - See "ensure_digests" task
 mac_workaround_image: "quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:0a516a6f646989cb1abe77696b19838ff6138f177b1e4df6970b7bc8938552df" # v0.2.3
 
 # mac workaround variables

--- a/trex-operator/relatedImages.yaml.in
+++ b/trex-operator/relatedImages.yaml.in
@@ -1,3 +1,5 @@
+# these two images are not hardcoded - they are replaced by the trex-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/trex-operator/Makefile - See "bundle" task
   relatedImages:
     - name: trex-container-server
       image: "quay.io/rh-nfv-int/trex-container-server@sha256:190d69aef293d1719952969edcca8042d99e17b0d62d1a085cdd7b01cb5e1f1d" # v0.2.6

--- a/trex-operator/roles/app/defaults/main.yml.in
+++ b/trex-operator/roles/app/defaults/main.yml.in
@@ -1,4 +1,6 @@
 ---
+# this image is not hardcoded - it is replaced by the trex-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/trex-operator/Makefile - See "ensure_digests" task
 image_app: "quay.io/rh-nfv-int/trex-container-app@sha256:da8c5aae7f2f7459d9d7b842880040cfde0ce301a9edc83e88ae9f27dc448829" # v0.2.6
 image_pull_policy: Always
 command: ["trex-wrapper"]

--- a/trex-operator/roles/server/defaults/main.yml.in
+++ b/trex-operator/roles/server/defaults/main.yml.in
@@ -1,4 +1,6 @@
 ---
+# these images are not hardcoded - they are replaced by the trex-operator Makefile launched by the Github actions defined for this repo
+# https://github.com/openshift-kni/example-cnf/blob/main/trex-operator/Makefile - See "ensure_digests" task
 image_server: "quay.io/rh-nfv-int/trex-container-server@sha256:190d69aef293d1719952969edcca8042d99e17b0d62d1a085cdd7b01cb5e1f1d" # v0.2.6
 image_app: "quay.io/rh-nfv-int/trex-container-app@sha256:da8c5aae7f2f7459d9d7b842880040cfde0ce301a9edc83e88ae9f27dc448829" # v0.2.6
 image_pull_policy: IfNotPresent


### PR DESCRIPTION
- The images that appear as hardcoded in the files under testpmd-lb-operator, testpmd-operator and trex-operator are eventually updated by the Github actions we have, including some comments just to make everyone aware of that.
- As part of this update process, we're missing one image to be updated, in testpmd-operator. Adding the same logic to make it work.
- Fix usage of DIGEST variable in one of the cases.