### PR TITLE
Revert DPDK container image to 4.6

### DIFF
--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/dpdk-base-rhel8:v4.14
+FROM registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6.3-8
 
 MAINTAINER skramaja@redhat.com
 

--- a/testpmd-operator/config/samples/examplecnf_v1_testpmd.yaml
+++ b/testpmd-operator/config/samples/examplecnf_v1_testpmd.yaml
@@ -3,7 +3,7 @@ kind: TestPMD
 metadata:
   name: testpmd-sample
 spec:
-  image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8:v4.14
+  image_testpmd: registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6.3-8
   size: 1
   ethpeerMaclist: ["20:04:0f:f1:89:01","20:04:0f:f1:89:02"]
   networks:

--- a/testpmd-operator/relatedImages.yaml.in
+++ b/testpmd-operator/relatedImages.yaml.in
@@ -1,6 +1,6 @@
   relatedImages:
     - name: testpmd-app
-      image: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:dccbad0b74151eb62bdd1ed9a1ec2d2588acc01db7cc126981795c8315bb678b"  # v4.14
+      image: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1"  # v4.6.3-8
     # this image is not hardcoded - it is replaced by the testpmd-operator Makefile launched by the Github actions defined for this repo
     # https://github.com/openshift-kni/example-cnf/blob/main/testpmd-operator/Makefile - See "bundle" task
     - name: testpmd-container-app-mac

--- a/testpmd-operator/roles/testpmd/defaults/main.yml.in
+++ b/testpmd-operator/roles/testpmd/defaults/main.yml.in
@@ -7,7 +7,7 @@ privileged: false
 network_defintions: ""
 network_resources: {}
 environments: {}
-image_testpmd: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:dccbad0b74151eb62bdd1ed9a1ec2d2588acc01db7cc126981795c8315bb678b"  # v4.14
+image_testpmd: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1"  # v4.6.3-8
 # this image is not hardcoded - it is replaced by the testpmd-operator Makefile launched by the Github actions defined for this repo
 # https://github.com/openshift-kni/example-cnf/blob/main/testpmd-operator/Makefile - See "ensure_digests" task
 mac_workaround_image: "quay.io/rh-nfv-int/testpmd-container-app-mac@sha256:0a516a6f646989cb1abe77696b19838ff6138f177b1e4df6970b7bc8938552df" # v0.2.3


### PR DESCRIPTION
build-depends: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/45

In https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/45, we could see that we were hardcoding the DPDK container image we use in example-cnf, we've been always running 4.6 (which, in fact, it is v4.6.3-8: https://catalog.redhat.com/software/containers/openshift4/dpdk-base-rhel8/5e32be6cdd19c77896004a41?image=6080ca15dd19c716b367d9bc&architecture=amd64&container-tabs=gti)

When testing the change in nfv-example-cnf-deploy to really run the image we have, which is v4.14, the execution failed, probably this needs more investigation.

So, now that we can make sure what's the image we're testing, just returning to previous DPDK container image version, to make sure we have something running, then we'll investigate the 4.14 version separately.