### PR TITLE
Set correct registry in DCI component data - URL field

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,7 +77,7 @@ jobs:
           '
           componentName: nfv-example-cnf-index
           componentVersion: v${{ needs.build_all.outputs.version }}
-          componentData: '{"url":"${{ env.REGISTRY }}/rh-nfv-int/nfv-example-cnf-catalog"}'
+          componentData: '{"url":"${{ env.QUAY_REGISTRY }}/rh-nfv-int/nfv-example-cnf-catalog"}'
           componentRelease: ga
 
       - name: Results


### PR DESCRIPTION
I forgot to update this field in https://github.com/openshift-kni/example-cnf/pull/38 and this is causing https://issues.redhat.com/browse/CILAB-1108 in daily jobs. This will fix the issue.