### PR TITLE
Transform testpmd-container-app-cnfapp into CentOS + DPDK binary

### DIFF
--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.5
+VERSION         ?= 0.2.6
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.5"}
+TAG=${TAG:-"v0.2.6"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -1,29 +1,75 @@
-FROM docker.io/library/golang:1.21 as build
+## Build image
+FROM quay.io/centos/centos:stream8 as build
+
+ENV DPDK_VER=19.11
+ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
+ENV RTE_TARGET=x86_64-native-linuxapp-gcc
+ENV RTE_SDK=${DPDK_DIR}
+
+# Install prerequisite packages
+RUN dnf groupinstall -y "Development Tools" && \
+    dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
+    dnf clean all
+
+# Download the DPDK libraries
+RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
+    tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
+    rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
+
+# Configuration
+RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' \
+    -e 's/KNI_KMOD=y/KNI_KMOD=n/' \
+    -e 's/LIBRTE_KNI=y/LIBRTE_KNI=n/' \
+    -e 's/LIBRTE_PMD_KNI=y/LIBRTE_PMD_KNI=n/' $DPDK_DIR/config/common_linux && \
+    sed -i 's/\(CONFIG_RTE_LIBRTE_MLX5_PMD=\)n/\1y/g' $DPDK_DIR/config/common_base
+
+# Build it
+RUN cd ${DPDK_DIR} && \
+    make install T=${RTE_TARGET} DESTDIR=${RTE_SDK} -j $(nproc)
+
+RUN cd ${DPDK_DIR}/app && \
+    cd ${DPDK_DIR}/app/test-pmd && \
+    make -j $(nproc) && \
+    cp testpmd /usr/local/bin
+
+# Image to build webserver
+FROM docker.io/library/golang:1.21 as build2
 
 WORKDIR /utils
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 
-FROM registry.redhat.io/openshift4/dpdk-base-rhel8:v4.6.3-8
+## testpmd image
+FROM quay.io/centos/centos:stream8
 
 MAINTAINER telcoci@redhat.com
 
 LABEL name="NFV Example CNF Application" \
       maintainer="telcoci@redhat.com" \
       vendor="fredco" \
-      version="v0.2.5" \
-      release="v0.2.5" \
+      version="v0.2.6" \
+      release="v0.2.6" \
       summary="An example CNF for platform valiation" \
       description="An example CNF for platform valiation"
 
 COPY licenses /licenses
 
-USER root
+# Required libraries and debugging tools
+RUN dnf install -y \
+    epel-release \
+    libibverbs \
+    logrotate \
+    numactl \
+    python3 \
+    rdma-core \
+    tcpdump \
+    && dnf clean all
 
 # Copy scripts
-COPY --chmod=550 scripts/entrypoint.sh /usr/local/bin/
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd
+COPY --chmod=550 scripts/testpmd-run /usr/local/bin/testpmd-run
 
 # Prepare entrypoint
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/testpmd-run"]

--- a/testpmd-container-app/cnfapp/scripts/entrypoint.sh
+++ b/testpmd-container-app/cnfapp/scripts/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-# Start lifecycle webserver in background
-/usr/local/bin/webserver 8095 &
-
-# Call to testpmd/run
-/bin/bash /var/lib/testpmd/run

--- a/testpmd-container-app/cnfapp/scripts/testpmd-run
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-run
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -ex
+
+# Start lifecycle webserver in background
+/usr/local/bin/webserver 8095 &
+
+echo "Running testpmd"
+
+RUN_APP=${run_app:=1}
+
+LOG_DIR="/var/log/testpmd"
+[ -d $LOG_DIR ] || mkdir -p $LOG_DIR
+rm -rf /var/log/testpmd/*
+
+MODE=${MODE:-"fwd"}
+
+if [ -z ${NETWORK_NAME_LIST} ]; then
+    echo "ERROR: NETWORK_NAME_LIST is required."
+    exit 1
+fi
+
+PCI=""
+IFS=',' read -r -a NETWORK_ARRAY <<< "$NETWORK_NAME_LIST"
+TESTPMD_ENV="/var/lib/testpmd/env.txt"
+echo "" > $TESTPMD_ENV
+for item in "${NETWORK_ARRAY[@]}"; do
+    IFS='/' read -r -a RES_ARRAY <<< "$item"
+    NAME="PCIDEVICE_OPENSHIFT_IO_${RES_ARRAY[1]^^}"
+    if [ -z ${!NAME} ]; then
+        echo "Could not find ${NAME} with PCI address, exiting"
+        exit 1
+    fi
+    echo "${NAME}=${!NAME}" >> $TESTPMD_ENV
+    IFS=',' read -r -a PCI_ARRAY <<< "${!NAME}"
+    for pci_item in "${PCI_ARRAY[@]}"; do
+        PCI+=" -w ${pci_item} "
+    done
+done
+
+LCORES=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+if [ -z $LCORES ]; then
+    echo "Could not find cores, existing.."
+    exit 1
+fi
+
+CORES_STR=$LCORES
+IFS=',' read -ra CORES_ARR <<< "$CORES_STR"
+CORES_LEN=${#CORES_ARR[@]}
+if [[ $CORES_LEN -gt $TESTPMD_CPU_COUNT ]]; then
+    echo "ERROR: Acutal cores (${CORES_LEN}) is greater than configured cores (${TESTPMD_CPU_COUNT})"
+    exit 1
+fi
+
+# TODO: remove it later
+eth_peer=${eth_peer:="0,60:04:0f:f1:89:01;1,60:04:0f:f1:89:02"}
+ETH_PEER=""
+IFS=';' read -ra ETH_PEER_LIST <<< "$eth_peer"
+for item in "${ETH_PEER_LIST[@]}"; do
+    ETH_PEER="${ETH_PEER} --eth-peer ${item}"
+done
+
+SOCKET_MEM=${socket_mem:=1024}
+MEMORY_CHANNELS=${memory_channels:=4}
+FORWARDING_CORES=${forwarding_cores:=2}
+RXQ=${rx_queues:=1}
+TXQ=${tx_queues:=1}
+RXD=${rx_descriptors:=1024}
+TXD=${tx_descriptors:=1024}
+STATS_PERIOD=${stats_period:=1}
+
+CMD="testpmd -l $LCORES --in-memory $PCI --socket-mem ${SOCKET_MEM} -n ${MEMORY_CHANNELS} --proc-type auto --file-prefix pg"
+CMD="${CMD} --"
+CMD="${CMD} --disable-rss --nb-cores=${FORWARDING_CORES} --rxq=${RXQ} --txq=${TXQ} --rxd=${RXD} --txd=${TXD}"
+CMD="${CMD} --auto-start ${ETH_PEER} --forward-mode=mac --stats-period ${STATS_PERIOD}"
+#CMD="${CMD} --cmdline-file /root/testpmd-runtime-cmds.txt"
+#CMD="${CMD} 2>&1 | tee /var/log/testpmd/app.log"
+
+function sig_term() {
+    echo $(date +"%F %T,%3N") > /var/log/testpmd/sigterm-received.log
+    # kill testpmd application
+    kill -9 $(ps aux | grep -w stats-period | grep -v grep | awk '{print $2}')
+    exit
+}
+trap sig_term SIGTERM
+
+if [[ $RUN_APP == "1" ]]; then
+    ${CMD} 2>&1 | tee /var/log/testpmd/app.log
+else
+    echo ${CMD} > /var/lib/testpmd/cmd
+    sleep infinity
+fi


### PR DESCRIPTION
- testpmd-container-app-cnfapp should not use DPDK container image from registry.redhat.io, due to the portability issues already documented
- Using CentOS Stream image with DPDK binary instead, following the same installation done in testpmd-container-app-testpmd image, but without Saravanan's patch for loadbalancer module, since it's not needed
- Including testpmd-run, which is the same script that is executed in the DPDK container image, in `/var/lib/testpmd/run`, and replacing the current scripts to use this as entrypoint