### PR TITLE
Fix networking-restart-on-reboot-sriov-pod tnf test

### DIFF
--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       example-cnf-type: lb-app
+      restart-on-reboot: "true"
   template:
     metadata:
       annotations:
@@ -27,6 +28,7 @@ spec:
         ]'
       labels:
         example-cnf-type: lb-app
+        restart-on-reboot: "true"
     spec:
       affinity:
         podAntiAffinity:

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       example-cnf-type: cnf-app
+      restart-on-reboot: "true"
   template:
     metadata:
 {% if not skip_annot|bool %}
@@ -32,6 +33,7 @@ spec:
 {% endif %}
       labels:
         example-cnf-type: cnf-app
+        restart-on-reboot: "true"
     spec:
       affinity:
         podAntiAffinity:

--- a/trex-operator/roles/server/templates/deployment.yml
+++ b/trex-operator/roles/server/templates/deployment.yml
@@ -8,10 +8,11 @@ spec:
   selector:
     matchLabels:
 {% if trex_server|bool %}
-        example-cnf-type: pkt-gen
+      example-cnf-type: pkt-gen
 {% elif trex_app|bool %}
-        example-cnf-type: pkt-gen-app
+      example-cnf-type: pkt-gen-app
 {% endif %}
+      restart-on-reboot: "true"
   template:
     metadata:
 {% if not skip_annot %}
@@ -38,6 +39,7 @@ spec:
 {% elif trex_app|bool %}
         example-cnf-type: pkt-gen-app
 {% endif %}
+        restart-on-reboot: "true"
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
This change targets the following tnf tests:

- networking-restart-on-reboot-sriov-pod
  - this test is fixed by adding `restart-on-reboot: "true"` label in pods that use SRIOV