### PR TITLE
Fix tnf tests related to cnf-app-mac-operator ServiceAccount

### DIFF
--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -82,8 +82,8 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects.
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -61,4 +61,5 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/cnf-app-mac-operator/config/rbac/kustomization.yaml
+++ b/cnf-app-mac-operator/config/rbac/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
-#- service_account.yaml
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/cnf-app-mac-operator/config/rbac/leader_election_role_binding.yaml
+++ b/cnf-app-mac-operator/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/cnf-app-mac-operator/config/rbac/role.yaml
+++ b/cnf-app-mac-operator/config/rbac/role.yaml
@@ -1,11 +1,9 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
-  namespace: example-cnf
 rules:
 - apiGroups:
   - ""

--- a/cnf-app-mac-operator/config/rbac/role_binding.yaml
+++ b/cnf-app-mac-operator/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/cnf-app-mac-operator/config/rbac/role_binding.yaml
+++ b/cnf-app-mac-operator/config/rbac/role_binding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: manager-role
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
This targets the following tests:

- access-control-pod-service-account
- access-control-pod-role-bindings

These tests are fixed by using a ServiceAccount different than default one in cnf-app-mac-operator. I've followed the same approach applied in the other three operators: use controller-manager ServiceAccount and ClusterRole/ClusterRoleBinding.

Also, I needed to remove the manual creation of the manager-role done with controller-gen CLI command in the Makefile. This is not done in the rest of operators, in fact.

As a consequence of the last change, this test is now skipped instead of failing:

- access-control-crd-roles