### PR TITLE
Address image-pull-policy and automount-SA-token tnf tests

### DIFF
--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         args:
         - --enable-leader-election
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         resources:
           limits:

--- a/testpmd-operator/localtest.yaml
+++ b/testpmd-operator/localtest.yaml
@@ -14,7 +14,7 @@
     vars:
       privileged: true
       image: jumphost.cluster5.dfwt5g.lab:5000/nfv-example-cnf/testpmd-container-app:v0.1.0
-      image_pull_policy: Always
+      image_pull_policy: IfNotPresent
       ethpeer_maclist:
         - 3c:fd:fe:79:2a:a0
         - 3c:fd:fe:79:2a:a1

--- a/trex-operator/localtest.yaml
+++ b/trex-operator/localtest.yaml
@@ -10,7 +10,7 @@
       namespace: example-cnf
     privileged: false
     image: quay.io/krsacme/trex-container-app:v0.0.1
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     size: 1
     networks:
       - name: vfdpdk1

--- a/trex-operator/roles/app/defaults/main.yml.in
+++ b/trex-operator/roles/app/defaults/main.yml.in
@@ -2,7 +2,7 @@
 # this image is not hardcoded - it is replaced by the trex-operator Makefile launched by the Github actions defined for this repo
 # https://github.com/openshift-kni/example-cnf/blob/main/trex-operator/Makefile - See "ensure_digests" task
 image_app: "quay.io/rh-nfv-int/trex-container-app@sha256:da8c5aae7f2f7459d9d7b842880040cfde0ce301a9edc83e88ae9f27dc448829" # v0.2.6
-image_pull_policy: Always
+image_pull_policy: IfNotPresent
 command: ["trex-wrapper"]
 environments: {}
 enable_lb: true

--- a/trex-operator/trex-allinone.yaml
+++ b/trex-operator/trex-allinone.yaml
@@ -238,7 +238,7 @@ spec:
         - --enable-leader-election
         - --leader-election-id=trex-operator
         image: jumphost.cluster5.dfwt5g.lab:5000/nfv-example-cnf/trex-operator:v0.1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         lifecycle:
           postStart:


### PR DESCRIPTION
This fixes:

- access-control-pod-automount-service-account-token
- lifecycle-image-pull-policy