### PR TITLE
Move cnfapp to DPDK 23.11

### DIFF
--- a/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
+++ b/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
@@ -446,7 +446,7 @@ func getContainerLogValue(podName, namespace string) (string, error) {
 	cmd := []string{
 		"sh",
 		"-c",
-		"egrep '^Port [0-9]: ([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$' /var/log/testpmd/app.log | sed 's/Port [0-9]: //'",
+		"egrep '^Port [0-9]: ([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$' /var/log/testpmd/app.log | sed 's/Port [0-9]: //'",
 	}
 	return executeCmdOnContainer(cmd, podName, namespace)
 }

--- a/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
+++ b/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
@@ -216,6 +216,11 @@ func (r *CNFAppMacReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	if macStr == "" {
+		log.Info("No MAC address retrieved, exiting")
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("Get mac string from command executed", "mac-string", macStr)
 
 	macs := strings.Split(strings.ReplaceAll(macStr, "\r\n", "\n"), "\n")

--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.7
+VERSION         ?= 0.2.8
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.7"}
+TAG=${TAG:-"v0.2.8"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -19,7 +19,7 @@ RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
 
 # Build it with support for mlx5 driver
 RUN cd ${DPDK_DIR} && \
-    meson setup -Dc_args='-DRTE_LIBRTE_MLX5_DEBUG' -Dexamples=all build && \
+    meson setup -Dc_args='-DRTE_LIBRTE_MLX5_DEBUG' -Dexamples=all -Dplatform=generic build && \
     cd build && \
     ninja && \
     meson install && \

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -1,38 +1,32 @@
 ## Build image
 FROM quay.io/centos/centos:stream8 as build
 
-ENV DPDK_VER=19.11
+ENV DPDK_VER=23.11
 ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
-ENV RTE_TARGET=x86_64-native-linuxapp-gcc
-ENV RTE_SDK=${DPDK_DIR}
 
 # Install prerequisite packages
 RUN dnf groupinstall -y "Development Tools" && \
-    dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
+    dnf install --skip-broken -y wget numactl numactl-devel gcc libibverbs-devel logrotate rdma-core tcpdump python39 && \
     dnf clean all
+
+# Install Meson, Ninja and pyelftools packages with pip, required to build DPDK. Python >= 3.7 is required
+RUN pip3.9 install meson ninja pyelftools
 
 # Download the DPDK libraries
 RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
     tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
     rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
 
-# Configuration
-RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' \
-    -e 's/KNI_KMOD=y/KNI_KMOD=n/' \
-    -e 's/LIBRTE_KNI=y/LIBRTE_KNI=n/' \
-    -e 's/LIBRTE_PMD_KNI=y/LIBRTE_PMD_KNI=n/' $DPDK_DIR/config/common_linux && \
-    sed -i 's/\(CONFIG_RTE_LIBRTE_MLX5_PMD=\)n/\1y/g' $DPDK_DIR/config/common_base
-
-# Build it
+# Build it with support for mlx5 driver
 RUN cd ${DPDK_DIR} && \
-    make install T=${RTE_TARGET} DESTDIR=${RTE_SDK} -j $(nproc)
+    meson setup -Dc_args='-DRTE_LIBRTE_MLX5_DEBUG' -Dexamples=all build && \
+    cd build && \
+    ninja && \
+    meson install && \
+    ldconfig && \
+    cp app/dpdk-testpmd /usr/local/bin
 
-RUN cd ${DPDK_DIR}/app && \
-    cd ${DPDK_DIR}/app/test-pmd && \
-    make -j $(nproc) && \
-    cp testpmd /usr/local/bin
-
-# Image to build webserver
+## Image to build webserver
 FROM docker.io/library/golang:1.21 as build2
 
 WORKDIR /utils
@@ -48,8 +42,8 @@ MAINTAINER telcoci@redhat.com
 LABEL name="NFV Example CNF Application" \
       maintainer="telcoci@redhat.com" \
       vendor="fredco" \
-      version="v0.2.6" \
-      release="v0.2.6" \
+      version="v0.2.8" \
+      release="v0.2.8" \
       summary="An example CNF for platform valiation" \
       description="An example CNF for platform valiation"
 
@@ -68,7 +62,7 @@ RUN dnf install -y \
 
 # Copy scripts
 COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
-COPY --chmod=550 --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd
+COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/testpmd
 COPY --chmod=550 scripts/testpmd-run /usr/local/bin/testpmd-run
 
 # Prepare entrypoint

--- a/testpmd-container-app/cnfapp/scripts/testpmd-run
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-run
@@ -34,7 +34,7 @@ for item in "${NETWORK_ARRAY[@]}"; do
     echo "${NAME}=${!NAME}" >> $TESTPMD_ENV
     IFS=',' read -r -a PCI_ARRAY <<< "${!NAME}"
     for pci_item in "${PCI_ARRAY[@]}"; do
-        PCI+=" -w ${pci_item} "
+        PCI+=" -a ${pci_item} "
     done
 done
 

--- a/trex-container-app/server/scripts/trex-cfg-configure
+++ b/trex-container-app/server/scripts/trex-cfg-configure
@@ -212,6 +212,7 @@ def get_dst_mac():
     except ApiException as e:
         return []
 
+    print(response)
     macs = []
     for item in response['items']:
         print(item['spec'].get('node'))

--- a/trex-container-app/server/scripts/trex-cfg-configure
+++ b/trex-container-app/server/scripts/trex-cfg-configure
@@ -212,7 +212,6 @@ def get_dst_mac():
     except ApiException as e:
         return []
 
-    print(response)
     macs = []
     for item in response['items']:
         print(item['spec'].get('node'))


### PR DESCRIPTION
- Moving to DPDK 23.11 in cnfapp image, changing the way DPDK is built, which moved from make to meson. Installing required packages for this to work and running proper commands
  - same work will be done for testpmd image in a separate change since it requires a reimplementation of Saravanan's patch
- Support for `EAL_IGB_UIO`, `KNI_KMOD`, `LIBRTE_KNI` and `LIBRTE_PMD_KNI` was removed in previous DPDK releases (after 19.11), so we don't need to do any modification for this
- Adding the proper argument in meson setup to include support for mlx5 driver
- Updating testpmd-run, `-w` is now `-a`, rest is the same
- Bumping img version to 0.2.8
- In cnf-app-mac-operator, the command used to retrieve MAC addresses from testpmd-app pods needed to be changed because the regex applied was not working, using the correct format now and adding more logs to better troubleshoot in the future