### PR TITLE
Fix for dual-stack and non-root tnf tests

### DIFF
--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -60,7 +60,6 @@ spec:
 {% if privileged %}
           privileged: true
 {% else %}
-          runAsUser: 0
           capabilities:
             add: ["IPC_LOCK", "NET_ADMIN"]
 {% endif %}

--- a/trex-operator/roles/server/tasks/main.yml
+++ b/trex-operator/roles/server/tasks/main.yml
@@ -44,6 +44,7 @@
         name: trex-server
         namespace: "{{ ansible_operator_meta.namespace }}"
       spec:
+        ipFamilyPolicy: "PreferDualStack"
         selector:
           example-cnf-type: pkt-gen
         ports:

--- a/trex-operator/trex-allinone.yaml
+++ b/trex-operator/trex-allinone.yaml
@@ -208,6 +208,7 @@ metadata:
   name: trex-operator-controller-manager-metrics-service
   namespace: example-cnf
 spec:
+  ipFamilyPolicy: "PreferDualStack"
   ports:
   - name: https
     port: 8443


### PR DESCRIPTION
This target these tnf tests:

- access-control-security-context-non-root-user-check - testpmd pods are using root user. Let's test without it; if testpmd-lb is working without root user, and we're using DPDK there too, it should make sense to avoid using root user in testpmd too. If not working, then we'll have to consider an exception for this
- networking-dual-stack-service - trex-server is the only resource failing here, adding the PreferDualStack field to be able to obtain dual-stack config if possible