### PR TITLE
Allow using more than one SRIOV network

### DIFF
--- a/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
+++ b/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
@@ -47,6 +47,30 @@ type CNFAppMacReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+type Device struct {
+	mac string
+	pci string
+}
+
+type Resource struct {
+	name    string
+	devices []Device
+}
+
+type Pci struct {
+	pciAddress string `json:"pci-address"`
+}
+
+type DeviceInfo struct {
+	pci Pci `json:"pci"`
+}
+
+type NetStatus struct {
+	name       string     `json:"name"`
+	mac        string     `json:"mac"`
+	deviceInfo DeviceInfo `json:"device-info"`
+}
+
 // getWatchNamespace returns the Namespace the operator should be watching for changes
 func getWatchNamespace() (string, error) {
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
@@ -134,98 +158,180 @@ func (r *CNFAppMacReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	podName := req.NamespacedName.Name
 	namespace := req.NamespacedName.Namespace
 
-	// Check if the pod has additional networks via NetworkAttachmentDefinitions
-	networkStr, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
-	var networks []map[string]interface{}
+	// Custom object we need to build the CNFAppMac CR
+	resInterface := []Resource{}
+
+	// Try using network-status annotation, else use the legacy method
+	netStatusStr, ok := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]
 	if ok {
-		log.Info("Network annotations for pod", "raw-net-annotations", networkStr)
-		json.Unmarshal([]byte(networkStr), &networks)
-		log.Info("Unmarshalled network annotations", "unmarshalled-net-annotations", networks)
-		if len(networks) == 0 {
+		// Remove line breaks and unmarshal the JSON object that represents the network-status annotation
+		netStatusStr = strings.TrimSuffix(netStatusStr, "\n")
+		var netStatus []NetStatus
+		log.Info("Network status for pod", "raw-net-status", netStatusStr)
+		json.Unmarshal([]byte(netStatusStr), &netStatus)
+		log.Info("Unmarshalled network status", "unmarshalled-net-status", netStatus)
+		if len(netStatus) == 0 {
 			return ctrl.Result{}, nil
 		}
-		// Check if one of the nework has hardcode mac, pod will be skipped
-		for _, item := range networks {
-			log.Info("Individual network item", "net-item", item)
-			if _, ok = item["mac"]; ok {
+
+		// Start retrieving the information we need:
+		// - for each network:
+		//	- extract MAC address
+		//	- extract PCI address
+		// if network already exists, just append MAC and PCI address, else add a new element
+		for _, item := range netStatus {
+			// This object also contains def iface info, we need to discard it (it doesn't have device-info field)
+			if item.name != "ovn-kubernetes" {
+				// Extract the data we need
+				rawNetName := item.name
+				netName := strings.Split(rawNetName, "/")[0]
+				macAddr := item.mac
+				pciAddr := item.deviceInfo.pci.pciAddress
+				log.Info("Extracted items", "net", netName, "mac", macAddr, "pci", pciAddr)
+
+				// Check if network is already saved in resInterface
+				// If that's true, then append MAC and PCI address to it
+				netExists := false
+				for i, netItem := range resInterface {
+					if netItem.name == netName {
+						log.Info("Network exists, status before updating it", "net-before", resInterface[i])
+						netExists = true
+						currentDevs := netItem.devices
+						dev := Device{
+							pci: pciAddr,
+							mac: macAddr,
+						}
+						currentDevs = append(currentDevs, dev)
+
+						// Let's build a new object to replace the current one
+						net := Resource{
+							name:    netName,
+							devices: currentDevs,
+						}
+						resInterface[i] = net
+						log.Info("Network status after updating it", "net-after", resInterface[i])
+					}
+				}
+				// If network does not exist, append new element to resInterface
+				if !netExists {
+					devInterface := []Device{}
+					dev := Device{
+						pci: pciAddr,
+						mac: macAddr,
+					}
+					devInterface = append(devInterface, dev)
+
+					net := Resource{
+						name:    netName,
+						devices: devInterface,
+					}
+					log.Info("Adding network to list", "net", net)
+					resInterface = append(resInterface, net)
+				}
+				log.Info("List status after iteration", "list", resInterface)
+			}
+		}
+
+		err = r.createCR(req, pod.UID, pod.Spec.NodeName, resInterface)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+	} else {
+		// Check if the pod has additional networks via NetworkAttachmentDefinitions
+		networkStr, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
+		var networks []map[string]interface{}
+		if ok {
+			log.Info("Network annotations for pod", "raw-net-annotations", networkStr)
+			json.Unmarshal([]byte(networkStr), &networks)
+			log.Info("Unmarshalled network annotations", "unmarshalled-net-annotations", networks)
+			if len(networks) == 0 {
 				return ctrl.Result{}, nil
 			}
-		}
-	} else {
-		// CNF application, but does not have required annotations
-		// This can be case of shift-on-stack where sriov-cnf will not work with annotations
-		// Try alternate method
-		log.Info("No network annotations for pod, trying alternative method")
-		err = r.getNetworksFromResources(req, pod, &networks)
-		if err != nil {
-			log.Error(err, "Failed to get Networks from Resources")
-			return ctrl.Result{}, err
-		}
-	}
-
-	log.Info("Pod Info", "Node", pod.Spec.NodeName)
-
-	var resourcesMapList []map[string]interface{}
-	if len(networks) > 0 {
-		var nwNameList []string
-		for _, item := range networks {
-			log.Info("Networks", "name", item["name"], "net-details", item)
-			if !containsString(nwNameList, item["name"].(string)) {
-				nwNameList = append(nwNameList, item["name"].(string))
+			// Check if one of the nework has hardcode mac, pod will be skipped
+			for _, item := range networks {
+				log.Info("Individual network item", "net-item", item)
+				if _, ok = item["mac"]; ok {
+					return ctrl.Result{}, nil
+				}
 			}
-		}
-
-		for _, nwName := range nwNameList {
-			// Get Resource name from the network name
-			netAttach := &unstructured.Unstructured{}
-			netAttach.SetKind("NetworkAttachmentDefinition")
-			netAttach.SetAPIVersion("k8s.cni.cncf.io/v1")
-			nmName := req.NamespacedName
-			nmName.Name = nwName
-			err = r.Get(ctx, nmName, netAttach)
+		} else {
+			// CNF application, but does not have required annotations
+			// This can be case of shift-on-stack where sriov-cnf will not work with annotations
+			// Try alternate method
+			log.Info("No network annotations for pod, trying alternative method")
+			err = r.getNetworksFromResources(req, pod, &networks)
 			if err != nil {
+				log.Error(err, "Failed to get Networks from Resources")
 				return ctrl.Result{}, err
 			}
-			log.Info("Resource name for network", "net", nwName, "resource", netAttach)
-			resName := netAttach.GetAnnotations()["k8s.v1.cni.cncf.io/resourceName"]
-			resourcesMap, _ := r.getResMap(resName, podName, namespace, nwName)
-			resourcesMapList = append(resourcesMapList, resourcesMap)
 		}
-	} else {
-		resStr, err := getContainerEnvValue(podName, namespace, "NETWORK_NAME_LIST")
-		log.Info("Resources", "NETWORK_NAME_LIST", resStr)
+
+		log.Info("Pod Info", "Node", pod.Spec.NodeName)
+
+		var resourcesMapList []map[string]interface{}
+		if len(networks) > 0 {
+			var nwNameList []string
+			for _, item := range networks {
+				log.Info("Networks", "name", item["name"], "net-details", item)
+				if !containsString(nwNameList, item["name"].(string)) {
+					nwNameList = append(nwNameList, item["name"].(string))
+				}
+			}
+
+			for _, nwName := range nwNameList {
+				// Get Resource name from the network name
+				netAttach := &unstructured.Unstructured{}
+				netAttach.SetKind("NetworkAttachmentDefinition")
+				netAttach.SetAPIVersion("k8s.cni.cncf.io/v1")
+				nmName := req.NamespacedName
+				nmName.Name = nwName
+				err = r.Get(ctx, nmName, netAttach)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				log.Info("Network attachment definition", "net", nwName, "resource", netAttach)
+				resName := netAttach.GetAnnotations()["k8s.v1.cni.cncf.io/resourceName"]
+				log.Info("Resource name for network", "resourceName", resName)
+				resourcesMap, _ := r.getResMap(resName, podName, namespace, nwName)
+				resourcesMapList = append(resourcesMapList, resourcesMap)
+			}
+		} else {
+			resStr, err := getContainerEnvValue(podName, namespace, "NETWORK_NAME_LIST")
+			log.Info("Resources", "NETWORK_NAME_LIST", resStr)
+			if err != nil {
+				log.Error(err, "Failed to get env NETWORK_NAME_LIST")
+				return ctrl.Result{}, err
+			}
+			resList := strings.Split(strings.ReplaceAll(resStr, "\r\n", ""), ",")
+			for _, resName := range resList {
+				resourcesMap, _ := r.getResMap(resName, podName, namespace, resName)
+				resourcesMapList = append(resourcesMapList, resourcesMap)
+			}
+		}
+
+		macStr, err := getContainerLogValue(req.NamespacedName.Name, req.NamespacedName.Namespace)
 		if err != nil {
-			log.Error(err, "Failed to get env NETWORK_NAME_LIST")
 			return ctrl.Result{}, err
 		}
-		resList := strings.Split(strings.ReplaceAll(resStr, "\r\n", ""), ",")
-		for _, resName := range resList {
-			resourcesMap, _ := r.getResMap(resName, podName, namespace, resName)
-			resourcesMapList = append(resourcesMapList, resourcesMap)
+
+		if macStr == "" {
+			log.Info("No MAC address retrieved, exiting")
+			return ctrl.Result{}, nil
 		}
-	}
 
-	macStr, err := getContainerLogValue(req.NamespacedName.Name, req.NamespacedName.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+		log.Info("Get mac string from command executed", "mac-string", macStr)
 
-	if macStr == "" {
-		log.Info("No MAC address retrieved, exiting")
-		return ctrl.Result{}, nil
-	}
+		macs := strings.Split(strings.ReplaceAll(macStr, "\r\n", "\n"), "\n")
 
-	log.Info("Get mac string from command executed", "mac-string", macStr)
+		log.Info("Get processed mac string from command executed", "processed-mac-string", macStr)
 
-	macs := strings.Split(strings.ReplaceAll(macStr, "\r\n", "\n"), "\n")
+		resInterface := generateResInterface(resourcesMapList, macs)
 
-	log.Info("Get processed mac string from command executed", "processed-mac-string", macs)
-
-	log.Info("Create CR for", "pod-uid", pod.UID, "node-name", pod.Spec.NodeName, "resources", resourcesMapList, "macs", macs)
-
-	err = r.createCR(req, pod.UID, pod.Spec.NodeName, resourcesMapList, macs)
-	if err != nil {
-		return ctrl.Result{}, err
+		err = r.createCR(req, pod.UID, pod.Spec.NodeName, resInterface)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil
@@ -253,33 +359,32 @@ func (r *CNFAppMacReconciler) getResMap(resName, podName, namespace, nwName stri
 	return resourcesMap, nil
 }
 
-func (r *CNFAppMacReconciler) createCR(req ctrl.Request, uid types.UID, nodename string, resourcesMapList []map[string]interface{}, macs []string) error {
-	log := r.Log.WithValues("cnfappmac", req.NamespacedName)
-	resInterface := []interface{}{}
+func generateResInterface(resourcesMapList []map[string]interface{}, macs []string) []Resource {
+	resInterface := []Resource{}
 	macIdx := 0
 	for _, item := range resourcesMapList {
-		log.Info("Create CR - check resource", "resource", item)
 		pciList := item["pci"].([]string)
-		devInterface := []interface{}{}
+		devInterface := []Device{}
 		for _, pci := range pciList {
-			log.Info("Create CR - check PCI", "pci", pci)
-			dev := map[string]interface{}{
-				"pci": pci,
-				"mac": macs[macIdx],
+			dev := Device{
+				pci: pci,
+				mac: macs[macIdx],
 			}
 			macIdx++
-			log.Info("Create CR - check dev", "dev", dev)
 			devInterface = append(devInterface, dev)
 		}
-		log.Info("Create CR - check devInterface", "devInterface", devInterface)
-		res := map[string]interface{}{
-			"name":    item["name"],
-			"devices": devInterface,
+		res := Resource{
+			name:    item["name"].(string),
+			devices: devInterface,
 		}
-		log.Info("Create CR - check res", "res", res)
 		resInterface = append(resInterface, res)
 	}
-	log.Info("Create CR - check resInterface", "resInterface", resInterface)
+
+	return resInterface
+}
+
+func (r *CNFAppMacReconciler) createCR(req ctrl.Request, uid types.UID, nodename string, resInterface []Resource) error {
+	log := r.Log.WithValues("cnfappmac", req.NamespacedName)
 
 	name := req.NamespacedName.Name
 	namespace := req.NamespacedName.Namespace
@@ -293,7 +398,6 @@ func (r *CNFAppMacReconciler) createCR(req ctrl.Request, uid types.UID, nodename
 		"uid":                uid,
 	}
 	owners = append(owners, owner)
-	log.Info("Create CR - check owners", "owners", owners)
 
 	macCR := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -334,7 +438,7 @@ func (r *CNFAppMacReconciler) getNetworksFromResources(req ctrl.Request, pod *co
 		return err
 	}
 
-	for k, _ := range pod.Spec.Containers[0].Resources.Limits {
+	for k := range pod.Spec.Containers[0].Resources.Limits {
 		netName, ok := r.getNetworkName(k, listObj)
 		if ok {
 			entry := map[string]interface{}{"name": netName}

--- a/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
+++ b/cnf-app-mac-operator/internal/controller/cnfappmac_controller.go
@@ -219,7 +219,9 @@ func (r *CNFAppMacReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	macs := strings.Split(strings.ReplaceAll(macStr, "\r\n", "\n"), "\n")
 
-	log.Info("Get processed mac string from command executed", "processed-mac-string", macStr)
+	log.Info("Get processed mac string from command executed", "processed-mac-string", macs)
+
+	log.Info("Create CR for", "pod-uid", pod.UID, "node-name", pod.Spec.NodeName, "resources", resourcesMapList, "macs", macs)
 
 	err = r.createCR(req, pod.UID, pod.Spec.NodeName, resourcesMapList, macs)
 	if err != nil {
@@ -256,22 +258,28 @@ func (r *CNFAppMacReconciler) createCR(req ctrl.Request, uid types.UID, nodename
 	resInterface := []interface{}{}
 	macIdx := 0
 	for _, item := range resourcesMapList {
+		log.Info("Create CR - check resource", "resource", item)
 		pciList := item["pci"].([]string)
 		devInterface := []interface{}{}
 		for _, pci := range pciList {
+			log.Info("Create CR - check PCI", "pci", pci)
 			dev := map[string]interface{}{
 				"pci": pci,
 				"mac": macs[macIdx],
 			}
 			macIdx++
+			log.Info("Create CR - check dev", "dev", dev)
 			devInterface = append(devInterface, dev)
 		}
+		log.Info("Create CR - check devInterface", "devInterface", devInterface)
 		res := map[string]interface{}{
 			"name":    item["name"],
 			"devices": devInterface,
 		}
+		log.Info("Create CR - check res", "res", res)
 		resInterface = append(resInterface, res)
 	}
+	log.Info("Create CR - check resInterface", "resInterface", resInterface)
 
 	name := req.NamespacedName.Name
 	namespace := req.NamespacedName.Namespace
@@ -285,6 +293,7 @@ func (r *CNFAppMacReconciler) createCR(req ctrl.Request, uid types.UID, nodename
 		"uid":                uid,
 	}
 	owners = append(owners, owner)
+	log.Info("Create CR - check owners", "owners", owners)
 
 	macCR := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/testpmd-lb-operator/roles/loadbalancer/tasks/main.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/tasks/main.yml
@@ -24,6 +24,10 @@
   set_fact:
     networks: "{{ packet_generator_networks + cnf_app_networks }}"
 
+- name: print networks
+  debug:
+    var: networks
+
 - name: "Parse CNF App network {{ network_item }}"
   include_tasks: network-parse.yaml
   loop: "{{ cnf_app_networks }}"
@@ -34,11 +38,31 @@
   set_fact:
     cnf_app_network_resources: "{{ network_resources }}"
 
+- name: print cnf_app_network_resources
+  debug:
+    var: cnf_app_network_resources
+
+- name: Updated network resources after reading cnf_app_networks
+  debug:
+    var: network_resources
+
+- name: Updated network name list after reading cnf_app_networks
+  debug:
+    var: network_name_list
+
 - name: "Parse Packet generator network {{ network_item }}"
   include_tasks: network-parse.yaml
   loop: "{{ packet_generator_networks }}"
   loop_control:
     loop_var: network_item
+
+- name: Updated network resources after reading packet_generator_networks
+  debug:
+    var: network_resources
+
+- name: Updated network name list after reading packet_generator_networks
+  debug:
+    var: network_name_list
 
 - name: Create ServiceAccount for LoadBalancer resource
   k8s:

--- a/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
+++ b/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
@@ -10,18 +10,42 @@
     net: "{{ network_item.name }}"
   when: "'/' not in network_item.name"
 
+- name: print net
+  debug:
+    var: net
+
 - set_fact:
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
+- name: print net_dev
+  debug:
+    var: net_dev
+
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"
+
+- name: print network_port_count
+  debug:
+    var: network_port_count
 
 - set_fact:
     network_resource_name: "{{ net_def['metadata']['annotations']['k8s.v1.cni.cncf.io/resourceName'] }}"
 
+- name: print network_resource_name
+  debug:
+    var: network_resource_name
+
 - set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
 
+- name: print network_resources
+  debug:
+    var: network_resources
+
 - set_fact:
     network_name_list: "{{ network_name_list + [net] }}"
+
+- name: print network_name_list
+  debug:
+    var: network_name_list

--- a/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
+++ b/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Gather network info of network: {{ network_item.name }}"
 
+- name: Initialize variable that checks if resource name is already on the dict
+  set_fact:
+    resource_exists: false
+
 - set_fact:
     net: "{{ network_item.name.split('/')[1] }}"
   when: "'/' in network_item.name"
@@ -36,8 +40,31 @@
   debug:
     var: network_resource_name
 
-- set_fact:
+- name: Update resource_exists if the resource is in the dict
+  set_fact:
+    resource_exists: true
+  with_dict: "{{ network_resources }}"
+  when: "network_resource_name in item.key"
+
+- name: print resource_exists
+  debug:
+    var: resource_exists
+
+- name: Include new network resource if it was not included before
+  set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
+  when: not resource_exists
+
+- name: Update network resource
+  block:
+    - name: Update count for network resource
+      set_fact:
+        network_resources: "{{ network_resources | combine(new_item, recursive=true) }}"
+      vars:
+        new_item: "{ '{{ item.key }}': {{ item.value|int + network_port_count|int }} }"
+      with_dict: "{{ network_resources }}"
+      when: "network_resource_name in item.key"
+  when: resource_exists
 
 - name: print network_resources
   debug:

--- a/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
+++ b/testpmd-lb-operator/roles/loadbalancer/tasks/network-parse.yaml
@@ -18,9 +18,9 @@
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
-- name: print net_dev
+- name: print net_def
   debug:
-    var: net_dev
+    var: net_def
 
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"

--- a/testpmd-operator/roles/testpmd/tasks/main.yml
+++ b/testpmd-operator/roles/testpmd/tasks/main.yml
@@ -33,12 +33,24 @@
   loop_control:
     index_var: idx
 
+- name: print eth_peer
+  debug:
+    var: eth_peer
+
 - name: "Parse network"
   include_tasks: network-parse.yaml
   when: networks|default([])|length > 0
   loop: "{{ networks }}"
   loop_control:
     loop_var: network_item
+
+- name: print network_resources after parsing networks
+  debug:
+    var: network_resources
+
+- name: print network_name_list after parsing networks
+  debug:
+    var: network_name_list
 
 - name: "Parse resources if defined and when sriov network is not defined"
   set_fact:

--- a/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
+++ b/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
@@ -10,18 +10,42 @@
     net: "{{ network_item.name }}"
   when: "'/' not in network_item.name"
 
+- name: print net
+  debug:
+    var: net
+
 - set_fact:
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
+- name: print net_dev
+  debug:
+    var: net_dev
+
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"
+
+- name: print network_port_count
+  debug:
+    var: network_port_count
 
 - set_fact:
     network_resource_name: "{{ net_def['metadata']['annotations']['k8s.v1.cni.cncf.io/resourceName'] }}"
 
+- name: print network_resource_name
+  debug:
+    var: network_resource_name
+
 - set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
 
+- name: print network_resources
+  debug:
+    var: network_resources
+
 - set_fact:
     network_name_list: "{{ network_name_list + [net] }}"
+
+- name: print network_name_list
+  debug:
+    var: network_name_list

--- a/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
+++ b/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Gather network info of network: {{ network_item.name }}"
 
+- name: Initialize variable that checks if resource name is already on the dict
+  set_fact:
+    resource_exists: false
+
 - set_fact:
     net: "{{ network_item.name.split('/')[1] }}"
   when: "'/' in network_item.name"
@@ -36,8 +40,31 @@
   debug:
     var: network_resource_name
 
-- set_fact:
+- name: Update resource_exists if the resource is in the dict
+  set_fact:
+    resource_exists: true
+  with_dict: "{{ network_resources }}"
+  when: "network_resource_name in item.key"
+
+- name: print resource_exists
+  debug:
+    var: resource_exists
+
+- name: Include new network resource if it was not included before
+  set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
+  when: not resource_exists
+
+- name: Update network resource
+  block:
+    - name: Update count for network resource
+      set_fact:
+        network_resources: "{{ network_resources | combine(new_item, recursive=true) }}"
+      vars:
+        new_item: "{ '{{ item.key }}': {{ item.value|int + network_port_count|int }} }"
+      with_dict: "{{ network_resources }}"
+      when: "network_resource_name in item.key"
+  when: resource_exists
 
 - name: print network_resources
   debug:

--- a/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
+++ b/testpmd-operator/roles/testpmd/tasks/network-parse.yaml
@@ -18,9 +18,9 @@
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
-- name: print net_dev
+- name: print net_def
   debug:
-    var: net_dev
+    var: net_def
 
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"

--- a/trex-operator/roles/server/tasks/main.yml
+++ b/trex-operator/roles/server/tasks/main.yml
@@ -9,10 +9,22 @@
     msg: "networks parameter is empty"
   when: networks|length == 0
 
+- name: print networks
+  debug:
+    var: networks
+
 - include_tasks: network-parse.yaml
   loop: "{{ networks }}"
   loop_control:
     loop_var: network_item
+
+- name: Updated network resources after reading networks
+  debug:
+    var: network_resources
+
+- name: Updated network name list after reading networks
+  debug:
+    var: network_name_list
 
 - name: Create ServiceAccount for TRex resource
   k8s:

--- a/trex-operator/roles/server/tasks/network-parse.yaml
+++ b/trex-operator/roles/server/tasks/network-parse.yaml
@@ -1,6 +1,7 @@
 ---
 - debug:
     msg: "Gather network info of network: {{ network_item.name }}"
+
 - set_fact:
     net: "{{ network_item.name.split('/')[1] }}"
   when: "'/' in network_item.name"
@@ -9,18 +10,42 @@
     net: "{{ network_item.name }}"
   when: "'/' not in network_item.name"
 
+- name: print net
+  debug:
+    var: net
+
 - set_fact:
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
+- name: print net_dev
+  debug:
+    var: net_dev
+
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"
+
+- name: print network_port_count
+  debug:
+    var: network_port_count
 
 - set_fact:
     network_resource_name: "{{ net_def['metadata']['annotations']['k8s.v1.cni.cncf.io/resourceName'] }}"
 
+- name: print network_resource_name
+  debug:
+    var: network_resource_name
+
 - set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
 
+- name: print network_resources
+  debug:
+    var: network_resources
+
 - set_fact:
     network_name_list: "{{ network_name_list + [net] }}"
+
+- name: print network_name_list
+  debug:
+    var: network_name_list

--- a/trex-operator/roles/server/tasks/network-parse.yaml
+++ b/trex-operator/roles/server/tasks/network-parse.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Gather network info of network: {{ network_item.name }}"
 
+- name: Initialize variable that checks if resource name is already on the dict
+  set_fact:
+    resource_exists: false
+
 - set_fact:
     net: "{{ network_item.name.split('/')[1] }}"
   when: "'/' in network_item.name"
@@ -36,8 +40,31 @@
   debug:
     var: network_resource_name
 
-- set_fact:
+- name: Update resource_exists if the resource is in the dict
+  set_fact:
+    resource_exists: true
+  with_dict: "{{ network_resources }}"
+  when: "network_resource_name in item.key"
+
+- name: print resource_exists
+  debug:
+    var: resource_exists
+
+- name: Include new network resource if it was not included before
+  set_fact:
     network_resources: "{{ network_resources | combine( {network_resource_name : network_port_count} ) }}"
+  when: not resource_exists
+
+- name: Update network resource
+  block:
+    - name: Update count for network resource
+      set_fact:
+        network_resources: "{{ network_resources | combine(new_item, recursive=true) }}"
+      vars:
+        new_item: "{ '{{ item.key }}': {{ item.value|int + network_port_count|int }} }"
+      with_dict: "{{ network_resources }}"
+      when: "network_resource_name in item.key"
+  when: resource_exists
 
 - name: print network_resources
   debug:

--- a/trex-operator/roles/server/tasks/network-parse.yaml
+++ b/trex-operator/roles/server/tasks/network-parse.yaml
@@ -18,9 +18,9 @@
     net_def: "{{ lookup('k8s', kind='NetworkAttachmentDefinition', namespace=ansible_operator_meta.namespace, resource_name=net) }}"
   failed_when: net_def|length == 0
 
-- name: print net_dev
+- name: print net_def
   debug:
-    var: net_dev
+    var: net_def
 
 - set_fact:
     network_port_count: "{{ network_item.count|default(1) }}"


### PR DESCRIPTION
- Currently, we're not supporting the usage of multiple SRIOV network resources per network, adding this feature in the Ansible playbooks and cnf-app-mac-operator's controller code
- Ansible playbook:
  - The main logic relies on network-status annotation; if not present, it will run the legacy code we previously have, just to keep compatibility with that case
  - Displaying variables defined with set_fact to troubleshoot in controller-manager logs, else they will not appear
- Controller code:
  - All the logic now relies in network-status annotation, which holds all the information we need. If that annotation cannot be retrieved from the pod, then use the legacy mode.
  - Note that I'm not an expert in Golang, maybe the code can be improved somehow, I've just kept it simple to read and to troubleshoot, adding logs in some places (you can check cnf-app-mac-operator-controller-manager logs and you will see the logs)