### PR TITLE
Install lshw in DPDK-related images

### DIFF
--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -58,6 +58,7 @@ RUN dnf install -y \
     python3 \
     rdma-core \
     tcpdump \
+    lshw \
     && dnf clean all
 
 # Copy scripts

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -55,6 +55,7 @@ RUN dnf install -y \
     python3 \
     rdma-core \
     tcpdump \
+    lshw \
     && dnf clean all
 
 # copy testpmd runtime cmdline file


### PR DESCRIPTION
Retrieving the MAC-PCI address using testpmd CLI is not really straighforward to be done in an automated basis. Instead, we may try with `lshw`, which looks like providing all the network info for the interfaces, including MAC address and PCI address. Let's test that.