### PR TITLE
Refactor cnf-app-mac-operator logic to ensure MAC-PCI binding is correct, add some logs in trex-cfg-configure for trex-container-app

### DIFF
--- a/trex-container-app/server/scripts/trex-cfg-configure
+++ b/trex-container-app/server/scripts/trex-cfg-configure
@@ -78,6 +78,10 @@ def main():
 
     src_mac = get_src_mac()
     if not src_mac:
+        print("Source mac address is not available, checking with PCI devices")
+        print("WARNING: this method is likely to fail")
+        # WARNING: if reaching this line (it should not happen normally, but it happened
+        # once while debugging), note that get_pci_mac is likely to fail
         src_mac = get_pci_mac(pci_list)
     if not src_mac:
         print("ERROR: Source mac address is not available, exiting...")
@@ -253,15 +257,18 @@ def get_pci_mac(pci_list):
     for pci in pci_list:
         print("get_pci_mac - starting with pci", pci)
         idx += 1
+        # The PCI device refers to a specific physfn
         path = "/sys/bus/pci/devices/" + pci + "/physfn/"
         pf = os.path.realpath(path)
         print("get_pci_mac - get pf path", pf)
-        print("get_pci_mac - get folders from pf + /net", ','.join(os.listdir(pf + "/net")))
+        # Try to extract the net for that physfn
+        # WARNING: it may happen that pf_name is empty, so get_vf_mac call will fail
         for item in os.listdir(pf + "/net"):
             pf_name = item
             print("get_pci_mac - extracted pf_name:", pf_name)
         print("get_pci_mac - get path", path)
         print("get_pci_mac - get folders from path", ','.join(os.listdir(path)))
+        # Look for the folder where we have the PCI address
         for item in os.listdir(path):
             print("get_pci_mac - extracted item from path:", item)
             if os.path.islink(path + item):
@@ -270,6 +277,7 @@ def get_pci_mac(pci_list):
                 if pci in rel:
                     vf = item.replace('virtfn', '')
                     print("get_pci_mac - this is the vf:", vf)
+                    # Apply the MAC address to that interface
                     get_vf_mac(pf_name, vf, mac[idx])
     return mac
 

--- a/trex-container-app/server/scripts/trex-cfg-configure
+++ b/trex-container-app/server/scripts/trex-cfg-configure
@@ -89,7 +89,7 @@ def main():
         print("destination mac obtained from lb_mac_string input - %s" % lb_mac_string)
     else:
         dst_mac = get_dst_mac()
-        print("destination mach fetched")
+        print("destination mac fetched")
 
     if not dst_mac:
         print("ERROR: Destination mac address is not available, exiting...")
@@ -173,12 +173,14 @@ def get_pci():
         print("pcis = %s" % pcis)
         pci_list = pcis.split(',')
         pci_all.extend(pci_list)
+    print("get_pci - All PCI addresses captured:", ','.join(pci_all))
     return pci_all
 
 def get_src_mac():
     podinfo = "/etc/podnetinfo/annotations"
     if not os.path.exists(podinfo):
         return []
+    print("get_src_mac - podinfo found")
     obj = []
     macs = []
     with open(podinfo) as f:
@@ -197,6 +199,7 @@ def get_src_mac():
                    random.getrandbits(8), random.getrandbits(8)]
             macStr = ':'.join(["%02x" % x for x in mac])
             macs.append(macStr)
+    print("get_src_mac - MACs found:", ','.join(macs))
     return macs
 
 def get_dst_mac():
@@ -218,6 +221,7 @@ def get_dst_mac():
         for resource in item['spec']['resources']:
             for dev in resource['devices']:
                 macs.append(dev['mac'])
+    print("get_dst_mac - Retrieved MAC addresses from testpmd-app:", ','.join(macs))
     return macs
 
 ###########################
@@ -247,16 +251,25 @@ def get_pci_mac(pci_list):
     mac = ["20:04:0f:f1:89:01","20:04:0f:f1:89:02"]
     idx = -1
     for pci in pci_list:
+        print("get_pci_mac - starting with pci", pci)
         idx += 1
         path = "/sys/bus/pci/devices/" + pci + "/physfn/"
         pf = os.path.realpath(path)
+        print("get_pci_mac - get pf path", pf)
+        print("get_pci_mac - get folders from pf + /net", ','.join(os.listdir(pf + "/net")))
         for item in os.listdir(pf + "/net"):
             pf_name = item
+            print("get_pci_mac - extracted pf_name:", pf_name)
+        print("get_pci_mac - get path", path)
+        print("get_pci_mac - get folders from path", ','.join(os.listdir(path)))
         for item in os.listdir(path):
+            print("get_pci_mac - extracted item from path:", item)
             if os.path.islink(path + item):
                 rel = os.path.realpath(path + item)
+                print("get_pci_mac - it is a link, real path:", rel)
                 if pci in rel:
                     vf = item.replace('virtfn', '')
+                    print("get_pci_mac - this is the vf:", vf)
                     get_vf_mac(pf_name, vf, mac[idx])
     return mac
 


### PR DESCRIPTION
- testpmd processes PCI addresses from lower to higher value, but this is not necessarily the same order followed by the network interfaces of the testpmd pods.
- As testpmd reorders the PCI interfaces when running DPDK workload, the same happens to MAC addresses.
- With https://github.com/dci-labs/dallas-config/pull/134, we will assume that PCI addresses are always in the correct order, else they may appear in higher-to-lower order and the job will fail, this cannot be avoided.
- I've refactored the code for cnf-app-mac-operator controller, removing the legacy code to create the structure required for CNFAppMac CR, now we can handle everything by following the order from annotations, and if MAC are not present, we directly extract them from testpmd logs, in whose case, we save the MAC address in reverse order (since it's the order expected by testpmd for that case)
- Discovered an issue in trex-cfg-configure from trex-container-app, when running the get_pci_mac function (this is not the normal case, don't know why I reached that point but I discovered this is not working as expected). I've just added some comments and prints to gather more logs in case it happens.

The code was tested locally with string vars and it's working as expected, then let's see if it has an impact on DCI jobs.

To check more information about why we have to do this, please check CILAB-291.