### PR TITLE
Add ports section to all containers deployed

### DIFF
--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -46,6 +46,11 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - name: "http-metric"
+          containerPort: 8080
+        - name: "http-probe"
+          containerPort: 8081
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/testpmd-lb-operator/config/manager/manager.yaml
+++ b/testpmd-lb-operator/config/manager/manager.yaml
@@ -45,13 +45,13 @@ spec:
         image: controller:latest
         name: manager
         ports:
-        - name: "tcp-lb-internal-one"
+        - name: "tcp-lb-int-one"
           containerPort: 5050
         - name: "http-probe"
           containerPort: 6789
         - name: "http-metric"
           containerPort: 8080
-        - name: "tcp-lb-internal-two"
+        - name: "tcp-lb-int-two"
           containerPort: 8888
         env:
         - name: ANSIBLE_GATHERING

--- a/testpmd-lb-operator/config/manager/manager.yaml
+++ b/testpmd-lb-operator/config/manager/manager.yaml
@@ -44,6 +44,15 @@ spec:
         - --leader-election-id=testpmd-lb-operator
         image: controller:latest
         name: manager
+        ports:
+        - name: "tcp-lb-internal-one"
+          containerPort: 5050
+        - name: "http-probe"
+          containerPort: 6789
+        - name: "http-metric"
+          containerPort: 8080
+        - name: "tcp-lb-internal-two"
+          containerPort: 8888
         env:
         - name: ANSIBLE_GATHERING
           value: explicit

--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -47,6 +47,9 @@ spec:
 {% endif %}
       containers:
       - name: loadbalancer
+        ports:
+        - name: "http-probe"
+          containerPort: 8095
         command: ["testpmd-wrapper"]
         args:
         - "--socket-mem {{ socket_memory }}"
@@ -142,6 +145,9 @@ spec:
           periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
       - name: listener
+        ports:
+        - name: "http-probe"
+          containerPort: 8096
         image: "{{ image_listener }}"
         imagePullPolicy: "{{ image_pull_policy }}"
         resources:

--- a/testpmd-operator/config/manager/manager.yaml
+++ b/testpmd-operator/config/manager/manager.yaml
@@ -46,13 +46,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         ports:
-        - name: "tcp-testpmd-internal-one"
+        - name: "tcp-tp-int-one"
           containerPort: 5050
         - name: "http-probe"
           containerPort: 6789
         - name: "http-metric"
           containerPort: 8080
-        - name: "tcp-testpmd-internal-two"
+        - name: "tcp-tp-int-two"
           containerPort: 8888
         env:
         - name: ANSIBLE_GATHERING

--- a/testpmd-operator/config/manager/manager.yaml
+++ b/testpmd-operator/config/manager/manager.yaml
@@ -45,6 +45,15 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - name: "tcp-testpmd-internal-one"
+          containerPort: 5050
+        - name: "http-probe"
+          containerPort: 6789
+        - name: "http-metric"
+          containerPort: 8080
+        - name: "tcp-testpmd-internal-two"
+          containerPort: 8888
         env:
         - name: ANSIBLE_GATHERING
           value: explicit

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -54,6 +54,9 @@ spec:
 {% endif %}
       containers:
       - name: testpmd
+        ports:
+        - name: "http-probe"
+          containerPort: 8095
         image: "{{ image_testpmd }}"
         imagePullPolicy: "{{ image_pull_policy }}"
         securityContext:

--- a/trex-operator/config/manager/manager.yaml
+++ b/trex-operator/config/manager/manager.yaml
@@ -35,6 +35,15 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - name: "tcp-trex-internal-one"
+          containerPort: 5050
+        - name: "http-probe"
+          containerPort: 6789
+        - name: "http-metric"
+          containerPort: 8080
+        - name: "tcp-trex-internal-two"
+          containerPort: 8888
         env:
           - name: ANSIBLE_GATHERING
             value: explicit

--- a/trex-operator/config/manager/manager.yaml
+++ b/trex-operator/config/manager/manager.yaml
@@ -36,13 +36,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         ports:
-        - name: "tcp-trex-internal-one"
+        - name: "tcp-tr-int-one"
           containerPort: 5050
         - name: "http-probe"
           containerPort: 6789
         - name: "http-metric"
           containerPort: 8080
-        - name: "tcp-trex-internal-two"
+        - name: "tcp-tr-int-two"
           containerPort: 8888
         env:
           - name: ANSIBLE_GATHERING

--- a/trex-operator/roles/server/templates/deployment.yml
+++ b/trex-operator/roles/server/templates/deployment.yml
@@ -64,6 +64,13 @@ spec:
         command: {{ command }}
         image: "{{ image_server }}"
         imagePullPolicy: "{{ image_pull_policy }}"
+        ports:
+        - name: "tcp-trex-one"
+          containerPort: 4500
+        - name: "tcp-trex-two"
+          containerPort: 4501
+        - name: "http-probe"
+          containerPort: 8096
         securityContext:
 {% if privileged %}
           privileged: true


### PR DESCRIPTION
This is to pass networking-undeclared-container-ports-usage tnf that is currently failing. Here we have the current failures, from this job: https://www.distributed-ci.io/jobs/cedb50bd-ba1e-4180-8306-4c49ee581d10/tests/cf01e2f8-8ec2-49cf-accc-2b703ebd1c11

```
{
  "CompliantObjectsOut": null,
  "NonCompliantObjectsOut": [
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "cnf-app-mac-operator-controller-manager-78c646dbd4-c9wqm",
        "8080",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "cnf-app-mac-operator-controller-manager-78c646dbd4-c9wqm",
        "8081",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "cnf-app-mac-operator-controller-manager-78c646dbd4-c9wqm"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-lb-operator-controller-manager-67b5c8dd5c-2gckj",
        "6789",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-lb-operator-controller-manager-67b5c8dd5c-2gckj",
        "5050",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-lb-operator-controller-manager-67b5c8dd5c-2gckj",
        "8888",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-lb-operator-controller-manager-67b5c8dd5c-2gckj",
        "8080",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "testpmd-lb-operator-controller-manager-67b5c8dd5c-2gckj"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-operator-controller-manager-58ff999c8f-vttrb",
        "8888",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-operator-controller-manager-58ff999c8f-vttrb",
        "5050",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-operator-controller-manager-58ff999c8f-vttrb",
        "8080",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-operator-controller-manager-58ff999c8f-vttrb",
        "6789",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "testpmd-operator-controller-manager-58ff999c8f-vttrb"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trex-operator-controller-manager-86cd696dd7-zdzdf",
        "5050",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trex-operator-controller-manager-86cd696dd7-zdzdf",
        "8888",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trex-operator-controller-manager-86cd696dd7-zdzdf",
        "6789",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trex-operator-controller-manager-86cd696dd7-zdzdf",
        "8080",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "trex-operator-controller-manager-86cd696dd7-zdzdf"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "loadbalancer-79b6c65bd4-z5ssj",
        "8095",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "loadbalancer-79b6c65bd4-z5ssj",
        "8096",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "loadbalancer-79b6c65bd4-z5ssj"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-app-5946886c75-jcqxv",
        "8095",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "testpmd-app-5946886c75-jcqxv"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "testpmd-app-5946886c75-s4wjt",
        "8095",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "testpmd-app-5946886c75-s4wjt"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trexconfig-74d8cff7f6-r8jw9",
        "4501",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trexconfig-74d8cff7f6-r8jw9",
        "4500",
        "TCP"
      ]
    },
    {
      "ObjectType": "Listening Port",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name",
        "Port Number",
        "Port Protocol"
      ],
      "ObjectFieldsValues": [
        "Listening port was declared in no container spec",
        "example-cnf",
        "trexconfig-74d8cff7f6-r8jw9",
        "8096",
        "TCP"
      ]
    },
    {
      "ObjectType": "Pod",
      "ObjectFieldsKeys": [
        "Reason For Non Compliance",
        "Namespace",
        "Pod Name"
      ],
      "ObjectFieldsValues": [
        "At least one port was listening but not declared in any container specs",
        "example-cnf",
        "trexconfig-74d8cff7f6-r8jw9"
      ]
    }
  ]
}
```

We just need to set up ports section and add these ports to declare they're being used.