### PR TITLE
Only set automountServiceAccountToken to false in testpmd-related pods

### DIFF
--- a/testpmd-operator/config/rbac/service_account.yaml
+++ b/testpmd-operator/config/rbac/service_account.yaml
@@ -10,4 +10,3 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system
-automountServiceAccountToken: false

--- a/testpmd-operator/roles/testpmd/templates/service_account.yml
+++ b/testpmd-operator/roles/testpmd/templates/service_account.yml
@@ -4,3 +4,4 @@ kind: ServiceAccount
 metadata:
   name: testpmd-account
   namespace: example-cnf
+automountServiceAccountToken: false

--- a/trex-operator/roles/server/templates/service_account.yml
+++ b/trex-operator/roles/server/templates/service_account.yml
@@ -4,4 +4,3 @@ kind: ServiceAccount
 metadata:
   name: trex-server-account
   namespace: example-cnf
-automountServiceAccountToken: false


### PR DESCRIPTION
It looks like https://github.com/openshift-kni/example-cnf/pull/74 caused https://issues.redhat.com/browse/CILAB-1603, and TRexConfig started to complain about service token not found, but this didn't happen, curiously, in the loadbalancer case.

Let's just use automountServiceAccountToken set to false in testpmd pods (testpmd-lb and testpmd operators), and removing the other cases, also testpmd-operator-controller-manager, which was added in the previous change by mistake.