### PR TITLE
Build controller managers in high availability mode

### DIFF
--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -36,6 +36,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: In
+                values:
+                - cnf-app-mac-operator
+            topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:

--- a/testpmd-lb-operator/config/manager/manager.yaml
+++ b/testpmd-lb-operator/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -36,6 +36,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: In
+                values:
+                - testpmd-lb-operator
+            topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:

--- a/testpmd-operator/config/manager/manager.yaml
+++ b/testpmd-operator/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -36,6 +36,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: In
+                values:
+                - testpmd-operator
+            topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:

--- a/trex-operator/config/manager/manager.yaml
+++ b/trex-operator/config/manager/manager.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -24,6 +24,16 @@ spec:
         control-plane: controller-manager
         example-cnf-type: trex-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/created-by
+                operator: In
+                values:
+                - trex-operator
+            topologyKey: kubernetes.io/hostname
       #securityContext:
       #  runAsNonRoot: true
       #  seccompProfile:


### PR DESCRIPTION
This try to address tnf test called lifecycle-pod-high-availability, just to explore if we can deploy controller managers in replicated mode.