### PR TITLE
Update securityContext spec for controller-managers to meet new CNF Cert operator tests criteria

### DIFF
--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -66,7 +66,6 @@ spec:
           capabilities:
             drop:
               - "ALL"
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
         env:
         - name: WATCH_NAMESPACE

--- a/cnf-app-mac-operator/config/manager/manager.yaml
+++ b/cnf-app-mac-operator/config/manager/manager.yaml
@@ -66,6 +66,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/testpmd-lb-operator/config/manager/manager.yaml
+++ b/testpmd-lb-operator/config/manager/manager.yaml
@@ -71,6 +71,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         lifecycle:
           postStart:
             exec:

--- a/testpmd-lb-operator/config/manager/manager.yaml
+++ b/testpmd-lb-operator/config/manager/manager.yaml
@@ -71,7 +71,6 @@ spec:
           capabilities:
             drop:
               - "ALL"
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
         lifecycle:
           postStart:

--- a/testpmd-operator/config/manager/manager.yaml
+++ b/testpmd-operator/config/manager/manager.yaml
@@ -79,6 +79,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testpmd-operator/config/manager/manager.yaml
+++ b/testpmd-operator/config/manager/manager.yaml
@@ -79,7 +79,6 @@ spec:
           capabilities:
             drop:
               - "ALL"
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
         livenessProbe:
           httpGet:

--- a/trex-operator/config/manager/manager.yaml
+++ b/trex-operator/config/manager/manager.yaml
@@ -62,7 +62,6 @@ spec:
           capabilities:
             drop:
               - "ALL"
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
         lifecycle:
           postStart:

--- a/trex-operator/config/manager/manager.yaml
+++ b/trex-operator/config/manager/manager.yaml
@@ -34,8 +34,8 @@ spec:
                 values:
                 - trex-operator
             topologyKey: kubernetes.io/hostname
-      #securityContext:
-      #  runAsNonRoot: true
+      securityContext:
+        runAsNonRoot: true
       #  seccompProfile:
       #    type: RuntimeDefault
       containers:
@@ -62,6 +62,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         lifecycle:
           postStart:
             exec:


### PR DESCRIPTION
Work made to pass this new CNF Cert Suite test:

- operator-run-as-non-root: `runAsNonRoot: true` must be set in the `securityContext of the pod and the container spec.

This only applies to the controller-manager pods, which are the scope of these new operator tests.