### PR TITLE
Get rid of CentOS 8 Stream repos and images

### DIFF
--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.9
+VERSION         ?= 0.2.10
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.9"}
+TAG=${TAG:-"v0.2.10"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -1,5 +1,7 @@
 ## Build image
-FROM quay.io/centos/centos:stream8 as build
+# Use Fedora as image to have access to all required packages
+# from Fedora repos (not requiring a RHEL subscription)
+FROM quay.io/fedora/fedora:latest as build
 
 ENV DPDK_VER=23.11
 ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
@@ -55,18 +57,26 @@ RUN dnf install -y \
     libibverbs \
     logrotate \
     python3 \
+    wget \
     && dnf clean all
 
-# Install prerequisite packages from CentOS Stream repos
-COPY files/centos8-base.repo /etc/yum.repos.d/centos8-base.repo
-COPY files/centos8-app.repo /etc/yum.repos.d/centos8-app.repo
-COPY files/centos8-extras.repo /etc/yum.repos.d/centos8-extras.repo
+# Install epel-release from EPEL-8 repository
+
+RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -P /tmp && \
+    cd /tmp && dnf install -y epel-release-latest-8.noarch.rpm
+
+# Install other required packages from Fedora repos
+# (not requiring a RHEL subscription)
+# .repo files obtained from Fedora container image
+COPY files/fedora-cisco-openh264.repo /etc/yum.repos.d/fedora-cisco-openh264.repo
+COPY files/fedora-updates-testing.repo /etc/yum.repos.d/fedora-updates-testing.repo
+COPY files/fedora-updates.repo /etc/yum.repos.d/fedora-updates.repo
+COPY files/fedora.repo /etc/yum.repos.d/fedora.repo
 
 RUN dnf install -y \
-    --enablerepo=centos8-base \
-    --enablerepo=centos8-app \
-    --enablerepo=centos8-extras \
-    epel-release \
+    --enablerepo=fedora-cisco-openh264 \
+    --enablerepo=updates \
+    --enablerepo=fedora \
     numactl \
     rdma-core \
     tcpdump \

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -15,9 +15,7 @@ RUN dnf groupinstall -y "Development Tools" && \
 RUN pip3.9 install meson ninja pyelftools
 
 # Download the DPDK libraries
-RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
-    tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
-    rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
+ADD http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.gz /usr/src
 
 # Build it with support for mlx5 driver
 RUN cd ${DPDK_DIR} && \

--- a/testpmd-container-app/cnfapp/files/centos8-app.repo
+++ b/testpmd-container-app/cnfapp/files/centos8-app.repo
@@ -1,5 +1,0 @@
-[centos8-app]
-name = CentOS 8 AppStream
-baseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/cnfapp/files/centos8-base.repo
+++ b/testpmd-container-app/cnfapp/files/centos8-base.repo
@@ -1,5 +1,0 @@
-[centos8-base]
-name = CentOS 8 Base OS
-baseurl = http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/cnfapp/files/centos8-extras.repo
+++ b/testpmd-container-app/cnfapp/files/centos8-extras.repo
@@ -1,5 +1,0 @@
-[centos8-extras]
-name = CentOS 8 Extras
-baseurl = http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/cnfapp/files/fedora-cisco-openh264.repo
+++ b/testpmd-container-app/cnfapp/files/fedora-cisco-openh264.repo
@@ -1,0 +1,29 @@
+[fedora-cisco-openh264]
+name=Fedora 40 openh264 (From Cisco) - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-debuginfo]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-source]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-source-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True

--- a/testpmd-container-app/cnfapp/files/fedora-updates-testing.repo
+++ b/testpmd-container-app/cnfapp/files/fedora-updates-testing.repo
@@ -1,0 +1,30 @@
+[updates-testing]
+name=Fedora 40 - x86_64 - Test Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-debuginfo]
+name=Fedora 40 - x86_64 - Test Updates Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-source]
+name=Fedora 40 - Test Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/testpmd-container-app/cnfapp/files/fedora-updates.repo
+++ b/testpmd-container-app/cnfapp/files/fedora-updates.repo
@@ -1,0 +1,30 @@
+[updates]
+name=Fedora 40 - x86_64 - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Fedora 40 - x86_64 - Updates - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-source]
+name=Fedora 40 - Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/testpmd-container-app/cnfapp/files/fedora.repo
+++ b/testpmd-container-app/cnfapp/files/fedora.repo
@@ -1,0 +1,30 @@
+[fedora]
+name=Fedora 40 - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-40&arch=x86_64
+enabled=0
+countme=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora 40 - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora 40 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -1,3 +1,22 @@
+## Image to extract DPDK libraries
+# In Fedora image, there are issues with tar command:
+# "Cannot change mode to xxxxxxx: Operation not permitted"
+# Proposed workaround is to disable seccomp: https://github.com/docker/docker-ce-packaging/issues/1012
+# Instead of that, let's decompress the content of DPDK
+# Use ubi8/ubi as image
+FROM registry.access.redhat.com/ubi8/ubi:latest as dpdk-build
+
+ENV DPDK_VER=19.11
+
+# Install prerequisite packages
+RUN dnf install --skip-broken -y wget xz && \
+    dnf clean all
+
+# Download the DPDK libraries
+RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
+    tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
+    rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
+
 ## Build image
 # Use Fedora as image to have access to all required packages
 # from Fedora repos (not requiring a RHEL subscription)
@@ -13,13 +32,11 @@ RUN dnf groupinstall -y "Development Tools" && \
     dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
     dnf clean all
 
-# Download the DPDK libraries
-ADD http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.gz /usr/src
+# Copy DPDK libraries
+COPY --from=dpdk-build /usr/src/dpdk-${DPDK_VER} /usr/src/dpdk-${DPDK_VER}
 
 # Copy patch
 COPY dpdk-${DPDK_VER}-lb.patch /usr/src/
-
-RUN ls -la /usr/src
 
 # Configuration
 RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' \

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -14,13 +14,12 @@ RUN dnf groupinstall -y "Development Tools" && \
     dnf clean all
 
 # Download the DPDK libraries
-RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /tmp && \
-    tar -xpvf /tmp/dpdk-${DPDK_VER}.tar.xz -C /tmp && \
-    rm -f /tmp/dpdk-${DPDK_VER}.tar.xz && \
-    mv /tmp/dpdk-${DPDK_VER} /usr/src
+ADD http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.gz /usr/src
 
 # Copy patch
 COPY dpdk-${DPDK_VER}-lb.patch /usr/src/
+
+RUN ls -la /usr/src
 
 # Configuration
 RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' \

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -1,5 +1,7 @@
 ## Build image
-FROM quay.io/centos/centos:stream8 as build
+# Use Fedora as image to have access to all required packages
+# from Fedora repos (not requiring a RHEL subscription)
+FROM quay.io/fedora/fedora:latest as build
 
 ENV DPDK_VER=19.11
 ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
@@ -12,9 +14,10 @@ RUN dnf groupinstall -y "Development Tools" && \
     dnf clean all
 
 # Download the DPDK libraries
-RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
-    tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
-    rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
+RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /tmp && \
+    tar -xpvf /tmp/dpdk-${DPDK_VER}.tar.xz -C /tmp && \
+    rm -f /tmp/dpdk-${DPDK_VER}.tar.xz && \
+    mv /tmp/dpdk-${DPDK_VER} /usr/src
 
 # Copy patch
 COPY dpdk-${DPDK_VER}-lb.patch /usr/src/
@@ -35,7 +38,7 @@ RUN cd ${DPDK_DIR}/app && patch -p2 < /usr/src/dpdk-${DPDK_VER}-lb.patch && \
     make -j $(nproc) && \
     cp testpmd /usr/local/bin
 
-# Image to build webserver
+## Image to build webserver
 FROM docker.io/library/golang:1.21 as build2
 
 WORKDIR /utils
@@ -52,18 +55,26 @@ RUN dnf install -y \
     libibverbs \
     logrotate \
     python3 \
+    wget \
     && dnf clean all
 
-# Install prerequisite packages from CentOS Stream repos
-COPY files/centos8-base.repo /etc/yum.repos.d/centos8-base.repo
-COPY files/centos8-app.repo /etc/yum.repos.d/centos8-app.repo
-COPY files/centos8-extras.repo /etc/yum.repos.d/centos8-extras.repo
+# Install epel-release from EPEL-8 repository
+
+RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -P /tmp && \
+    cd /tmp && dnf install -y epel-release-latest-8.noarch.rpm
+
+# Install other required packages from Fedora repos
+# (not requiring a RHEL subscription)
+# .repo files obtained from Fedora container image
+COPY files/fedora-cisco-openh264.repo /etc/yum.repos.d/fedora-cisco-openh264.repo
+COPY files/fedora-updates-testing.repo /etc/yum.repos.d/fedora-updates-testing.repo
+COPY files/fedora-updates.repo /etc/yum.repos.d/fedora-updates.repo
+COPY files/fedora.repo /etc/yum.repos.d/fedora.repo
 
 RUN dnf install -y \
-    --enablerepo=centos8-base \
-    --enablerepo=centos8-app \
-    --enablerepo=centos8-extras \
-    epel-release \
+    --enablerepo=fedora-cisco-openh264 \
+    --enablerepo=updates \
+    --enablerepo=fedora \
     numactl \
     rdma-core \
     tcpdump \

--- a/testpmd-container-app/testpmd/files/centos8-app.repo
+++ b/testpmd-container-app/testpmd/files/centos8-app.repo
@@ -1,5 +1,0 @@
-[centos8-app]
-name = CentOS 8 AppStream
-baseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/testpmd/files/centos8-base.repo
+++ b/testpmd-container-app/testpmd/files/centos8-base.repo
@@ -1,5 +1,0 @@
-[centos8-base]
-name = CentOS 8 Base OS
-baseurl = http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/testpmd/files/centos8-extras.repo
+++ b/testpmd-container-app/testpmd/files/centos8-extras.repo
@@ -1,5 +1,0 @@
-[centos8-extras]
-name = CentOS 8 Extras
-baseurl = http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/testpmd-container-app/testpmd/files/fedora-cisco-openh264.repo
+++ b/testpmd-container-app/testpmd/files/fedora-cisco-openh264.repo
@@ -1,0 +1,29 @@
+[fedora-cisco-openh264]
+name=Fedora 40 openh264 (From Cisco) - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-debuginfo]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-source]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-source-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True

--- a/testpmd-container-app/testpmd/files/fedora-updates-testing.repo
+++ b/testpmd-container-app/testpmd/files/fedora-updates-testing.repo
@@ -1,0 +1,30 @@
+[updates-testing]
+name=Fedora 40 - x86_64 - Test Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-debuginfo]
+name=Fedora 40 - x86_64 - Test Updates Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-source]
+name=Fedora 40 - Test Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/testpmd-container-app/testpmd/files/fedora-updates.repo
+++ b/testpmd-container-app/testpmd/files/fedora-updates.repo
@@ -1,0 +1,30 @@
+[updates]
+name=Fedora 40 - x86_64 - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Fedora 40 - x86_64 - Updates - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-source]
+name=Fedora 40 - Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/testpmd-container-app/testpmd/files/fedora.repo
+++ b/testpmd-container-app/testpmd/files/fedora.repo
@@ -1,0 +1,30 @@
+[fedora]
+name=Fedora 40 - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-40&arch=x86_64
+enabled=0
+countme=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora 40 - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora 40 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False

--- a/trex-container-app/Makefile
+++ b/trex-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.9
+VERSION         ?= 0.2.10
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/trex-container-app/build.sh
+++ b/trex-container-app/build.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
-TAG="${TAG:-v0.2.9}"
+TAG="${TAG:-v0.2.10}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -36,13 +36,18 @@ RUN dnf install -y \
     vim \
     && dnf clean all
 
-# Install prerequisite packages from CentOS Stream repos
-COPY files/centos8-base.repo /etc/yum.repos.d/centos8-base.repo
-COPY files/centos8-app.repo /etc/yum.repos.d/centos8-app.repo
+# Install other required packages from Fedora repos
+# (not requiring a RHEL subscription)
+# .repo files obtained from Fedora container image
+COPY files/fedora-cisco-openh264.repo /etc/yum.repos.d/fedora-cisco-openh264.repo
+COPY files/fedora-updates-testing.repo /etc/yum.repos.d/fedora-updates-testing.repo
+COPY files/fedora-updates.repo /etc/yum.repos.d/fedora-updates.repo
+COPY files/fedora.repo /etc/yum.repos.d/fedora.repo
 
 RUN dnf install -y \
-    --enablerepo=centos8-base \
-    --enablerepo=centos8-app \
+    --enablerepo=fedora-cisco-openh264 \
+    --enablerepo=updates \
+    --enablerepo=fedora \
     numactl \
     numactl-devel \
     nfs-utils \

--- a/trex-container-app/server/files/centos8-app.repo
+++ b/trex-container-app/server/files/centos8-app.repo
@@ -1,5 +1,0 @@
-[centos8-app]
-name = CentOS 8 AppStream
-baseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/trex-container-app/server/files/centos8-base.repo
+++ b/trex-container-app/server/files/centos8-base.repo
@@ -1,5 +1,0 @@
-[centos8-base]
-name = CentOS 8 Base OS
-baseurl = http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-gpgcheck = 0
-enabled = 0

--- a/trex-container-app/server/files/fedora-cisco-openh264.repo
+++ b/trex-container-app/server/files/fedora-cisco-openh264.repo
@@ -1,0 +1,29 @@
+[fedora-cisco-openh264]
+name=Fedora 40 openh264 (From Cisco) - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-debuginfo]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True
+
+[fedora-cisco-openh264-source]
+name=Fedora 40 openh264 (From Cisco) - x86_64 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-source-40&arch=x86_64
+type=rpm
+enabled=0
+metadata_expire=14d
+repo_gpgcheck=0
+gpgcheck=0
+skip_if_unavailable=True

--- a/trex-container-app/server/files/fedora-updates-testing.repo
+++ b/trex-container-app/server/files/fedora-updates-testing.repo
@@ -1,0 +1,30 @@
+[updates-testing]
+name=Fedora 40 - x86_64 - Test Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-debuginfo]
+name=Fedora 40 - x86_64 - Test Updates Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-testing-source]
+name=Fedora 40 - Test Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/trex-container-app/server/files/fedora-updates.repo
+++ b/trex-container-app/server/files/fedora-updates.repo
@@ -1,0 +1,30 @@
+[updates]
+name=Fedora 40 - x86_64 - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f40&arch=x86_64
+enabled=0
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Fedora 40 - x86_64 - Updates - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False
+
+[updates-source]
+name=Fedora 40 - Updates Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f40&arch=x86_64
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+metadata_expire=6h
+skip_if_unavailable=False

--- a/trex-container-app/server/files/fedora.repo
+++ b/trex-container-app/server/files/fedora.repo
@@ -1,0 +1,30 @@
+[fedora]
+name=Fedora 40 - x86_64
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-40&arch=x86_64
+enabled=0
+countme=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora 40 - x86_64 - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora 40 - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-40&arch=x86_64
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False


### PR DESCRIPTION
- Replace centos8 stream images by fedora images, which are publicly available and does not require RH subscription for the repos
- Replace centos8 repos by fedora repos, same reason
- For epel-release, download epel rpm from fedora mirror, which is also publicly available
- As a result, remove all references to centos-8-stream since it's now EOL