### PR TITLE
Force build-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ $ ip -s -d link show dev ens2f0
 Utils
 ------------------------
 
-Under [utils](utils) folder, you can find some utilities included in example-cnf to extend the functionalities offered by the tool.
+Under [utils](utils) folder, you can find some utilities included in example-cnf to extend the functionalities offered by the tool:
 
 - [webserver.go](utils/webserver.go): a Golang-based webserver to implement liveness, readiness and startup probes in the container images offered in [testpmd-container-app](testpmd-container-app) and [trex-container-app](trex-container-app) folders. The Makefiles offered in these directories take care of copying the webserver code from the utils directory to each image's directory.
 - [required-annotations.yaml](utils/required-annotations.yaml): annotations to be appended to the CSVs to pass Preflight's RequiredAnnotations tests. They are appended automatically thanks to the Makefile tasks from each operator.


### PR DESCRIPTION
Last merged PR didn't pass the [build-all check](https://github.com/openshift-kni/example-cnf/actions/runs/10185800252/job/28198406248), so the example-cnf image was not built.

I think it was because one of the commits included a single quote, because it's complaining in the "Dump GitHub context" task. I have made a small change here to rebuild the image and then publish it in Quay.