### PR TITLE
Include USER entry in Dockerfile to pass preflight - RunAsNonRoot test

### DIFF
--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.11
+VERSION         ?= 0.2.12
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.11"}
+TAG=${TAG:-"v0.2.12"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -33,9 +33,6 @@ RUN mkdir -p /var/log/testpmd
 RUN chmod 750 /var/log/testpmd
 RUN chown example-cnf /var/log/testpmd
 
-# Change some permissions on files that will require modifications during execution
-RUN chmod 664 /var/lib/testpmd/env.txt
-
 # Copy scripts
 COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/webserver
 COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/testpmd

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -28,6 +28,14 @@ RUN useradd example-cnf
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf
 
+# Allow example-cnf to use sudo permissions without asking for password
+RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
+
+# Create a folder managed by the custom user to place the scripts to launch
+RUN mkdir -p /usr/local/bin/example-cnf
+RUN chmod 750 /usr/local/bin/example-cnf
+RUN chown example-cnf /usr/local/bin/example-cnf
+
 # Create some support folders that will be needed during execution
 RUN mkdir -p /var/log/testpmd
 RUN chmod 750 /var/log/testpmd
@@ -35,11 +43,11 @@ RUN chown example-cnf /var/log/testpmd
 
 # Copy scripts
 COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/webserver
-COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/testpmd
-COPY --chmod=550 scripts/testpmd-run /usr/local/bin/testpmd-run
+COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/example-cnf/testpmd
+COPY --chmod=550 scripts/testpmd-wrapper /usr/local/bin/example-cnf/testpmd-wrapper
 
 # Move to the custom user
 USER example-cnf
 
 # Prepare entrypoint
-ENTRYPOINT ["/usr/local/bin/testpmd-run"]
+ENTRYPOINT ["/usr/local/bin/example-cnf/testpmd-wrapper"]

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -22,12 +22,27 @@ LABEL name="NFV Example CNF Application" \
 
 COPY licenses /licenses
 
+# Create custom user to avoid using root account
+RUN useradd example-cnf
+
+# This is to be able to manage some files that belong to root account
+RUN usermod -a -G root example-cnf
+
+# Create some support folders that will be needed during execution
+RUN mkdir -p /var/log/testpmd
+RUN chmod 750 /var/log/testpmd
+RUN chown example-cnf /var/log/testpmd
+
+# Change some permissions on files that will require modifications during execution
+RUN chmod 664 /var/lib/testpmd/env.txt
+
 # Copy scripts
-COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/webserver
 COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/testpmd
 COPY --chmod=550 scripts/testpmd-run /usr/local/bin/testpmd-run
 
-USER 65532:65532
+# Move to the custom user
+USER example-cnf
 
 # Prepare entrypoint
 ENTRYPOINT ["/usr/local/bin/testpmd-run"]

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -27,5 +27,7 @@ COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
 COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/testpmd
 COPY --chmod=550 scripts/testpmd-run /usr/local/bin/testpmd-run
 
+USER 65532:65532
+
 # Prepare entrypoint
 ENTRYPOINT ["/usr/local/bin/testpmd-run"]

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -79,12 +79,15 @@ RXD=${rx_descriptors:=1024}
 TXD=${tx_descriptors:=1024}
 STATS_PERIOD=${stats_period:=1}
 
-CMD="testpmd -l $LCORES --in-memory $PCI --socket-mem ${SOCKET_MEM} -n ${MEMORY_CHANNELS} --proc-type auto --file-prefix pg"
+RUN="/usr/local/bin/example-cnf/testpmd-run"
+CMD="/usr/local/bin/example-cnf/testpmd"
+CMD="${CMD} -l $LCORES --in-memory $PCI --socket-mem ${SOCKET_MEM} -n ${MEMORY_CHANNELS} --proc-type auto --file-prefix pg"
 CMD="${CMD} --"
 CMD="${CMD} --disable-rss --nb-cores=${FORWARDING_CORES} --rxq=${RXQ} --txq=${TXQ} --rxd=${RXD} --txd=${TXD}"
 CMD="${CMD} --auto-start ${ETH_PEER} --forward-mode=mac --stats-period ${STATS_PERIOD}"
-#CMD="${CMD} --cmdline-file /root/testpmd-runtime-cmds.txt"
-#CMD="${CMD} 2>&1 | tee /var/log/testpmd/app.log"
+CMD="${CMD} 2>&1 | tee /var/log/testpmd/app.log"
+echo "${CMD}" > $RUN
+chmod +x $RUN
 
 function sig_term() {
     echo $(date +"%F %T,%3N") > /var/log/testpmd/sigterm-received.log
@@ -95,8 +98,7 @@ function sig_term() {
 trap sig_term SIGTERM
 
 if [[ $RUN_APP == "1" ]]; then
-    ${CMD} 2>&1 | tee /var/log/testpmd/app.log
+    sudo /usr/local/bin/example-cnf/testpmd-run
 else
-    echo ${CMD} > /var/lib/testpmd/cmd
     sleep infinity
 fi

--- a/testpmd-container-app/listener/Dockerfile
+++ b/testpmd-container-app/listener/Dockerfile
@@ -21,7 +21,9 @@ USER root
 RUN pip3 install kubernetes
 
 # Copy scripts
-COPY scripts /usr/local/bin
+COPY --chmod=550 scripts /usr/local/bin
 COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+
+USER 65532:65532
 
 ENTRYPOINT ["testpmd-wrapper"]

--- a/testpmd-container-app/listener/Dockerfile
+++ b/testpmd-container-app/listener/Dockerfile
@@ -17,13 +17,27 @@ LABEL name="NFV Example Listener Application" \
 
 COPY licenses /licenses
 
+# Install Kubernetes
 USER root
 RUN pip3 install kubernetes
 
+# Create custom user to avoid using root account
+RUN useradd example-cnf
+
+# This is to be able to manage some files that belong to root account
+RUN usermod -a -G root example-cnf
+
+# Create some support folders that will be needed during execution
+RUN mkdir -p /var/log/testpmd
+RUN chmod 750 /var/log/testpmd
+RUN chown example-cnf /var/log/testpmd
+
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
 
-USER 65532:65532
+# Move to the custom user
+USER example-cnf
 
-ENTRYPOINT ["testpmd-wrapper"]
+# Prepare entrypoint
+ENTRYPOINT ["/usr/local/bin/testpmd-wrapper"]

--- a/testpmd-container-app/listener/scripts/testpmd-wrapper
+++ b/testpmd-container-app/listener/scripts/testpmd-wrapper
@@ -11,7 +11,7 @@ RUN_APP=${run_app:=1}
 
 LOG_FILE="/var/log/testpmd/app.log"
 
-# Wait till the /var/log/testpmd.log file is created
+# Wait till the /var/log/testpmd/app.log file is created
 n=5
 if [[ $RUN_APP == "0" ]]; then
     # add extra deploy for debugging

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -22,12 +22,32 @@ LABEL name="NFV Example Testpmd LB Application" \
 
 COPY licenses /licenses
 
+# Create custom user to avoid using root account
+RUN useradd example-cnf
+
+# This is to be able to manage some files that belong to root account
+RUN usermod -a -G root example-cnf
+
+# Create a folder managed by the custom user to place the scripts to launch
+RUN mkdir -p /usr/local/bin/example-cnf
+RUN chmod 750 /usr/local/bin/example-cnf
+RUN chown example-cnf /usr/local/bin/example-cnf
+
+# Create some support folders that will be needed during execution
+RUN mkdir -p /var/log/testpmd
+RUN chmod 750 /var/log/testpmd
+RUN chown example-cnf /var/log/testpmd
+
+# Change some permissions on files that will require modifications during execution
+RUN chmod 664 /var/lib/testpmd/env.txt
+
 # copy testpmd runtime cmdline file
-COPY testpmd-runtime-cmds.txt /root/testpmd-runtime-cmds.txt
+COPY --chmod=550 testpmd-runtime-cmds.txt /usr/local/bin/example-cnf/testpmd-runtime-cmds.txt
 
 # Copy scripts
-COPY --chmod=550 scripts /usr/local/bin
-COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
-COPY --chmod=550 --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd
+COPY --chmod=550 scripts /usr/local/bin/example-cnf
+COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/webserver
+COPY --chmod=550 --from=build /usr/local/bin/testpmd /usr/local/bin/example-cnf/testpmd
 
-USER 65532:65532
+# Move to the custom user
+USER example-cnf

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -28,6 +28,9 @@ RUN useradd example-cnf
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf
 
+# Allow example-cnf to use sudo permissions without asking for password
+RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
+
 # Create a folder managed by the custom user to place the scripts to launch
 RUN mkdir -p /usr/local/bin/example-cnf
 RUN chmod 750 /usr/local/bin/example-cnf

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -26,6 +26,8 @@ COPY licenses /licenses
 COPY testpmd-runtime-cmds.txt /root/testpmd-runtime-cmds.txt
 
 # Copy scripts
-COPY scripts /usr/local/bin
+COPY --chmod=550 scripts /usr/local/bin
 COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/
-COPY --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd
+COPY --chmod=550 --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd
+
+USER 65532:65532

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -38,9 +38,6 @@ RUN mkdir -p /var/log/testpmd
 RUN chmod 750 /var/log/testpmd
 RUN chown example-cnf /var/log/testpmd
 
-# Change some permissions on files that will require modifications during execution
-RUN chmod 664 /var/lib/testpmd/env.txt
-
 # copy testpmd runtime cmdline file
 COPY --chmod=550 testpmd-runtime-cmds.txt /usr/local/bin/example-cnf/testpmd-runtime-cmds.txt
 

--- a/testpmd-container-app/testpmd/scripts/testpmd-wrapper
+++ b/testpmd-container-app/testpmd/scripts/testpmd-wrapper
@@ -83,13 +83,13 @@ else
 fi
 
 STATS_PERIOD=${stats_period:=1}
-RUN="/usr/local/bin/testpmd-run"
+RUN="/usr/local/bin/example-cnf/testpmd-run"
 CMD="testpmd"
 CMD="${CMD} -l $LCORES"
 CMD="${CMD} $PCI"
 CMD="${CMD} $@"
 CMD="${CMD} --stats-period ${STATS_PERIOD}"
-CMD="${CMD} --cmdline-file /root/testpmd-runtime-cmds.txt"
+CMD="${CMD} --cmdline-file /usr/local/bin/example-cnf/testpmd-runtime-cmds.txt"
 
 if [[ "$MODE" == "lb" ]]; then
     CMD="${CMD} --enable-lb "

--- a/testpmd-container-app/testpmd/scripts/testpmd-wrapper
+++ b/testpmd-container-app/testpmd/scripts/testpmd-wrapper
@@ -19,9 +19,9 @@ if [ -z ${NETWORK_NAME_LIST} ]; then
         exit 1
     fi
     echo "NETWORK_NAME_LIST is empty, lb mode, running directly"
-    PCI=$(lb-direct --pci)
-    LCORES=$(lb-direct --lcore)
-    CNF_PCI=$(lb-direct --dutpci)
+    PCI=$(/usr/local/bin/example-cnf/lb-direct --pci)
+    LCORES=$(/usr/local/bin/example-cnf/lb-direct --lcore)
+    CNF_PCI=$(/usr/local/bin/example-cnf/lb-direct --dutpci)
 else
     PCI=""
     IFS=',' read -r -a NETWORK_ARRAY <<< "$NETWORK_NAME_LIST"
@@ -57,7 +57,7 @@ else
         exit 1
     fi
     
-    CORES_STR=$(expand-cpus)
+    CORES_STR=$(/usr/local/bin/example-cnf/expand-cpus)
     IFS=',' read -ra CORES_ARR <<< "$CORES_STR"
     CORES_LEN=${#CORES_ARR[@]}
     if [[ $CORES_LEN -gt $TESTPMD_CPU_COUNT ]]; then
@@ -109,7 +109,7 @@ function sig_term() {
 trap sig_term SIGTERM
 
 if [[ $RUN_APP == "1" ]]; then
-    testpmd-run
+    /usr/local/bin/example-cnf/testpmd-run
 else
     sleep infinity
 fi

--- a/testpmd-container-app/testpmd/scripts/testpmd-wrapper
+++ b/testpmd-container-app/testpmd/scripts/testpmd-wrapper
@@ -84,7 +84,7 @@ fi
 
 STATS_PERIOD=${stats_period:=1}
 RUN="/usr/local/bin/example-cnf/testpmd-run"
-CMD="testpmd"
+CMD="/usr/local/bin/example-cnf/testpmd"
 CMD="${CMD} -l $LCORES"
 CMD="${CMD} $PCI"
 CMD="${CMD} $@"

--- a/testpmd-container-app/testpmd/scripts/testpmd-wrapper
+++ b/testpmd-container-app/testpmd/scripts/testpmd-wrapper
@@ -109,7 +109,7 @@ function sig_term() {
 trap sig_term SIGTERM
 
 if [[ $RUN_APP == "1" ]]; then
-    /usr/local/bin/example-cnf/testpmd-run
+    sudo /usr/local/bin/example-cnf/testpmd-run
 else
     sleep infinity
 fi

--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -82,7 +82,7 @@ spec:
           privileged: true
 {% else %}
           capabilities:
-            add: ["IPC_LOCK", "NET_ADMIN"]
+            add: ["IPC_LOCK", "NET_ADMIN", "AUDIT_WRITE"]
 {% endif %}
         resources:
           limits:

--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -57,7 +57,7 @@ spec:
         ports:
         - name: "http-probe"
           containerPort: 8095
-        command: ["testpmd-wrapper"]
+        command: ["/usr/local/bin/example-cnf/testpmd-wrapper"]
         args:
         - "--socket-mem {{ socket_memory }}"
         - "-n {{ memory_channels }}"

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -65,7 +65,7 @@ spec:
           privileged: true
 {% else %}
           capabilities:
-            add: ["IPC_LOCK", "NET_ADMIN"]
+            add: ["IPC_LOCK", "NET_ADMIN", "AUDIT_WRITE"]
 {% endif %}
         resources:
           limits:

--- a/trex-container-app/Makefile
+++ b/trex-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.11
+VERSION         ?= 0.2.12
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -23,7 +23,7 @@ ENV TRAFFICGEN_REPO https://github.com/atheurer/trafficgen
 
 USER root
 
-RUN yum install -y nc sudo && yum clean all
+RUN yum install -y nc && yum clean all
 RUN mkdir -p /opt/trex && cd /opt/trex && git clone --branch ${TREX_VER}  ${TREX_REPO}
 RUN cd /opt && git clone  ${TRAFFICGEN_REPO}
 RUN pip3 install pyyaml kubernetes
@@ -38,13 +38,10 @@ RUN useradd example-cnf
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf
 
-# Allow example-cnf to use sudo permissions without asking for password
-RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
-
 # Create some support folders that will be needed during execution
 RUN mkdir -p /var/log/trex
 RUN chmod 750 /var/log/trex
-RUN chown example-cnf /var/log/trex
+RUN chown example-cnf:example-cnf /var/log/trex
 
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin/

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -23,7 +23,7 @@ ENV TRAFFICGEN_REPO https://github.com/atheurer/trafficgen
 
 USER root
 
-RUN yum install -y nc && yum clean all
+RUN yum install -y nc sudo && yum clean all
 RUN mkdir -p /opt/trex && cd /opt/trex && git clone --branch ${TREX_VER}  ${TREX_REPO}
 RUN cd /opt && git clone  ${TRAFFICGEN_REPO}
 RUN pip3 install pyyaml kubernetes

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -38,6 +38,9 @@ RUN useradd example-cnf
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf
 
+# Allow example-cnf to use sudo permissions without asking for password
+RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
+
 # Create some support folders that will be needed during execution
 RUN mkdir -p /var/log/trex
 RUN chmod 750 /var/log/trex

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -32,11 +32,24 @@ ENV PYTHONPATH="/opt/trex/trex-core/scripts/automation/trex_control_plane/intera
 ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
+# Create custom user to avoid using root account
+RUN useradd example-cnf
+
+# This is to be able to manage some files that belong to root account
+RUN usermod -a -G root example-cnf
+
+# Create some support folders that will be needed during execution
+RUN mkdir -p /var/log/trex
+RUN chmod 750 /var/log/trex
+RUN chown example-cnf /var/log/trex
+
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin/
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
 COPY --chmod=550 pyfiles /opt/pyfiles/
 
-USER 65532:65532
+# Move to the custom user
+USER example-cnf
 
-ENTRYPOINT ["trex-wrapper"]
+# Prepare entrypoint
+ENTRYPOINT ["/usr/local/bin/trex-wrapper"]

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -33,8 +33,10 @@ ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
 # Copy scripts
-COPY scripts /usr/local/bin/
+COPY --chmod=550 scripts /usr/local/bin/
 COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
-COPY pyfiles /opt/pyfiles/
+COPY --chmod=550 pyfiles /opt/pyfiles/
+
+USER 65532:65532
 
 ENTRYPOINT ["trex-wrapper"]

--- a/trex-container-app/app/pyfiles/logger.py
+++ b/trex-container-app/app/pyfiles/logger.py
@@ -7,11 +7,11 @@ log = logging.getLogger('run-trex')
 log.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-fh = logging.FileHandler('/var/log/run-trex.log')
+fh = logging.FileHandler('/var/log/trex/run-trex.log')
 fh.setLevel(logging.DEBUG)
 fh.setFormatter(formatter)
 
-fhd = logging.FileHandler('/var/log/trex.log')
+fhd = logging.FileHandler('/var/log/trex/trex.log')
 fhd.setLevel(logging.DEBUG)
 fhd.setFormatter(formatter)
 

--- a/trex-container-app/app/scripts/trex-wrapper
+++ b/trex-container-app/app/scripts/trex-wrapper
@@ -19,6 +19,10 @@ if [[ "${MODE}" == "direct" ]]; then
   RUN_APP=3
 fi
 
+LOG_DIR="/var/log/trex"
+[ -d $LOG_DIR ] || mkdir -p $LOG_DIR
+rm -rf /var/log/trex/*
+
 # wait for trex server to be ready
 count=120
 while [[ ${count} -gt 0 ]]; do
@@ -52,15 +56,15 @@ if [[ $RUN_APP == "1" ]]; then
     # leave the server running for 10s before starting application
     sleep 10
     echo_ts "Running TRex ..."
-    sudo /usr/local/bin/run-trex
+    /usr/local/bin/run-trex
 elif [[ $RUN_APP == "2" ]]; then
     sleep 10
     echo_ts "Running binary search"
-    sudo /usr/local/bin/run-binary-search
+    /usr/local/bin/run-binary-search
 elif [[ $RUN_APP == "3" ]]; then
     sleep 10
     echo_ts "Running TRex in direct mode (without LB)"
-    sudo /usr/local/bin/run-trex-direct
+    /usr/local/bin/run-trex-direct
 else
     echo_ts "Skipping TRex run, waiting ..."
     sleep infinity

--- a/trex-container-app/app/scripts/trex-wrapper
+++ b/trex-container-app/app/scripts/trex-wrapper
@@ -52,15 +52,15 @@ if [[ $RUN_APP == "1" ]]; then
     # leave the server running for 10s before starting application
     sleep 10
     echo_ts "Running TRex ..."
-    run-trex
+    sudo /usr/local/bin/run-trex
 elif [[ $RUN_APP == "2" ]]; then
     sleep 10
     echo_ts "Running binary search"
-    run-binary-search
+    sudo /usr/local/bin/run-binary-search
 elif [[ $RUN_APP == "3" ]]; then
     sleep 10
     echo_ts "Running TRex in direct mode (without LB)"
-    run-trex-direct
+    sudo /usr/local/bin/run-trex-direct
 else
     echo_ts "Skipping TRex run, waiting ..."
     sleep infinity

--- a/trex-container-app/build.sh
+++ b/trex-container-app/build.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
-TAG="${TAG:-v0.2.11}"
+TAG="${TAG:-v0.2.12}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -69,6 +69,10 @@ RUN usermod -a -G root example-cnf
 # Allow example-cnf to use sudo permissions without asking for password
 RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
 
+# Make sure /etc/trex_cfg.yaml is present and with proper permissions
+RUN touch /etc/trex_cfg.yaml
+RUN chmod 664 /etc/trex_cfg.yaml
+
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin
 COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -60,8 +60,15 @@ WORKDIR /opt/trex/trex-core/scripts
 ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
+# Create custom user to avoid using root account
+RUN useradd example-cnf
+
+# This is to be able to manage some files that belong to root account
+RUN usermod -a -G root example-cnf
+
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
 
-USER 65532:65532
+# Move to the custom user
+USER example-cnf

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -66,6 +66,9 @@ RUN useradd example-cnf
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf
 
+# Allow example-cnf to use sudo permissions without asking for password
+RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
+
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin
 COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -61,5 +61,7 @@ ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
 # Copy scripts
-COPY scripts /usr/local/bin
+COPY --chmod=550 scripts /usr/local/bin
 COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/
+
+USER 65532:65532

--- a/trex-container-app/server/scripts/trex-server
+++ b/trex-container-app/server/scripts/trex-server
@@ -18,6 +18,7 @@ cd $TREX_DIR
 n=0
 until [ "$n" -ge 5 ]
 do
+   cd /opt/trex/trex-core/scripts
    ./_t-rex-64 -i --no-hw-flow-stat -c $CORE_COUNT
    n=$((n+1))
    sleep 5

--- a/trex-container-app/server/scripts/trex-wrapper
+++ b/trex-container-app/server/scripts/trex-wrapper
@@ -34,9 +34,9 @@ if [[ $MODE == "lb" ]]; then
         sleep infinity
         exit 1
     fi
-    sudo /usr/local/bin/trex-cfg-configure $CORES $LB_MACS
+    /usr/local/bin/trex-cfg-configure $CORES $LB_MACS
 else
-    sudo /usr/local/bin/trex-cfg-configure $CORES
+    /usr/local/bin/trex-cfg-configure $CORES
 fi
 
 # Read the number of cores from the trex cfg
@@ -53,7 +53,7 @@ if [[ $((CORE_COUNT_CFG + 2)) != $TREX_CPU ]]; then
     exit 1
 fi
 
-SERVER="sudo /usr/local/bin/trex-server"
+SERVER="sudo -E /usr/local/bin/trex-server"
 
 if [[ $RUN_SERVER == "1" ]]; then
     sleep $RUN_DELAY

--- a/trex-container-app/server/scripts/trex-wrapper
+++ b/trex-container-app/server/scripts/trex-wrapper
@@ -54,7 +54,6 @@ if [[ $((CORE_COUNT_CFG + 2)) != $TREX_CPU ]]; then
 fi
 
 SERVER="/usr/local/bin/trex-server"
-chmod +x $SERVER
 
 if [[ $RUN_SERVER == "1" ]]; then
     sleep $RUN_DELAY

--- a/trex-container-app/server/scripts/trex-wrapper
+++ b/trex-container-app/server/scripts/trex-wrapper
@@ -34,9 +34,9 @@ if [[ $MODE == "lb" ]]; then
         sleep infinity
         exit 1
     fi
-    trex-cfg-configure $CORES $LB_MACS
+    sudo /usr/local/bin/trex-cfg-configure $CORES $LB_MACS
 else
-    trex-cfg-configure $CORES
+    sudo /usr/local/bin/trex-cfg-configure $CORES
 fi
 
 # Read the number of cores from the trex cfg
@@ -53,7 +53,7 @@ if [[ $((CORE_COUNT_CFG + 2)) != $TREX_CPU ]]; then
     exit 1
 fi
 
-SERVER="/usr/local/bin/trex-server"
+SERVER="sudo /usr/local/bin/trex-server"
 
 if [[ $RUN_SERVER == "1" ]]; then
     sleep $RUN_DELAY

--- a/trex-operator/roles/app/templates/job.yml
+++ b/trex-operator/roles/app/templates/job.yml
@@ -24,9 +24,6 @@ spec:
       - name: trex-app
         image: "{{ image_app }}"
         imagePullPolicy: "{{ image_pull_policy }}"
-        securityContext:
-          capabilities:
-            add: ["AUDIT_WRITE"]
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/trex-operator/roles/app/templates/job.yml
+++ b/trex-operator/roles/app/templates/job.yml
@@ -24,6 +24,9 @@ spec:
       - name: trex-app
         image: "{{ image_app }}"
         imagePullPolicy: "{{ image_pull_policy }}"
+        securityContext:
+          capabilities:
+            add: ["AUDIT_WRITE"]
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/trex-operator/roles/server/templates/deployment.yml
+++ b/trex-operator/roles/server/templates/deployment.yml
@@ -83,7 +83,7 @@ spec:
           privileged: true
 {% else %}
           capabilities:
-            add: ["IPC_LOCK", "NET_ADMIN"]
+            add: ["IPC_LOCK", "NET_ADMIN", "AUDIT_WRITE"]
 {% endif %}
         resources:
           limits:

--- a/utils/support-images/dpdk-19.11/Dockerfile
+++ b/utils/support-images/dpdk-19.11/Dockerfile
@@ -7,7 +7,7 @@ ENV RTE_SDK=${DPDK_DIR}
 
 # Install prerequisite packages
 RUN dnf groupinstall -y "Development Tools" && \
-    dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
+    dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump sudo && \
     dnf clean all
 
 # Download the DPDK libraries

--- a/utils/support-images/dpdk-23.11/Dockerfile
+++ b/utils/support-images/dpdk-23.11/Dockerfile
@@ -5,7 +5,7 @@ ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
 
 # Install prerequisite packages
 RUN dnf groupinstall -y "Development Tools" && \
-    dnf install --skip-broken -y wget numactl numactl-devel gcc libibverbs-devel logrotate rdma-core tcpdump python39 && \
+    dnf install --skip-broken -y wget numactl numactl-devel gcc libibverbs-devel logrotate rdma-core tcpdump python39 sudo && \
     dnf clean all
 
 # Install Meson, Ninja and pyelftools packages with pip, required to build DPDK. Python >= 3.7 is required

--- a/utils/support-images/ubi8-base-testpmd/Dockerfile
+++ b/utils/support-images/ubi8-base-testpmd/Dockerfile
@@ -12,4 +12,5 @@ RUN dnf install -y \
     numactl \
     rdma-core \
     tcpdump \
+    sudo \
     && dnf clean all

--- a/utils/support-images/ubi8-base-trex/Dockerfile
+++ b/utils/support-images/ubi8-base-trex/Dockerfile
@@ -7,4 +7,5 @@ RUN dnf install -y \
     nfs-utils \
     perf \
     tcpdump \
+    sudo \
     && dnf clean all


### PR DESCRIPTION
**Problem**

RunAsNonRoot preflight's test is not passing in multiple container images. Error is the following:

```
time="2024-08-02T08:42:12Z" level=debug msg="running check" check=RunAsNonRoot
time="2024-08-02T08:42:12Z" level=info msg="detected empty USER. Presumed to be running as root"
time="2024-08-02T08:42:12Z" level=info msg="USER value must be provided and be a non-root value for this check to pass"
time="2024-08-02T08:42:12Z" level=info msg="check completed" check=RunAsNonRoot result=FAILED
```

**Solution**

- Creating a non-root user, example-cnf, with sudo permissions in the container images that require it (particularly cnfapp, testpmd and trex-server), including USER entry in the Dockerfile of the affected images to use example-cnf user
- This example-cnf user requires to belong to the root group, in order to manage some files that belongs to root. For this, some permissions have been changed to allow permissions in users belonging to root group. For some other files and folders not located in root folders, ownership has been changed to example-cnf user
- Using absolute paths in most of the scripts, to avoid issues with calls with sudo
- Include AUDIT_WRITE capability in the pods that require sudo usage, so that sudo error messages are not printed
- Installing sudo in support images, since it's not provided by default

**Tests**

- [x] Loadbalancer mode - https://www.distributed-ci.io/jobs/8ed914cf-3d42-4250-9a39-e88c0959aa06/jobStates?sort=date
- [x] Direct mode - https://www.distributed-ci.io/jobs/dece3576-964e-4cc8-90a2-2ba2d55eda52/jobStates?sort=date