### PR TITLE
Reduce Quay image expiration from 2 weeks to 1 week

### DIFF
--- a/cnf-app-mac-operator/Makefile
+++ b/cnf-app-mac-operator/Makefile
@@ -328,7 +328,7 @@ bundle-build: bundle ## Build the bundle image.
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
 		-t bundle . ; \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=2w \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=1w \
 		-t bundle . ; \
 	fi
 
@@ -351,7 +351,7 @@ operator-build: kustomize ## Build the operator image
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG} -t $(REL_IMG); \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=2w -t ${IMG}; \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=1w -t ${IMG}; \
 	fi
 
 .PHONY: operator-push

--- a/nfv-example-cnf-index/Makefile
+++ b/nfv-example-cnf-index/Makefile
@@ -59,7 +59,7 @@ index-build: opm
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile -t $(INDEX_IMG) -t $(REL_INDEX_IMG) ;\
 	else \
-	BUILDAH_FORMAT=docker podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile --label quay.expires-after=2w -t $(INDEX_IMG) ;\
+	BUILDAH_FORMAT=docker podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile --label quay.expires-after=1w -t $(INDEX_IMG) ;\
 	fi; \
 	rm -rf $(BUILD_PATH) ;\
 	}

--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -46,7 +46,7 @@ build-testpmd: testpmd-dependencies
 	if [ -n "$(RELEASE)" ]; then \
 	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(VERSION)" $(CONTAINER_ARGS); \
 	else \
-	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=2w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
+	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=1w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
 	fi
 
 .PHONY: build-listener # Build listener
@@ -54,7 +54,7 @@ build-listener: listener-dependencies
 	if [ -n "$(RELEASE)" ]; then \
 	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(VERSION)" $(CONTAINER_ARGS); \
 	else \
-	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=2w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
+	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=1w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
 	fi
 
 .PHONY: build-cnfapp # Build cnfapp
@@ -62,7 +62,7 @@ build-cnfapp: cnfapp-dependencies
 	if [ -n "$(RELEASE)" ]; then \
 	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(VERSION)" $(CONTAINER_ARGS); \
 	else \
-	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=2w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
+	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=1w -t "$(REGISTRY)/$(ORG)/testpmd-container-app-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
 	fi
 
 .PHONY: clean # Delete untracked changes

--- a/testpmd-lb-operator/Makefile
+++ b/testpmd-lb-operator/Makefile
@@ -127,7 +127,7 @@ operator-build: ensure_digests
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG} -t $(REL_IMG) ;\
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=2w -t ${IMG} ;\
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=1w -t ${IMG} ;\
 	fi
 
 # Push the operator image
@@ -237,7 +237,7 @@ bundle-build: bundle
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
 		-t bundle . ; \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=2w \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=1w \
 		-t bundle . ; \
 	fi
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -128,7 +128,7 @@ operator-build: ensure_digests
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG} -t $(REL_IMG); \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=2w -t ${IMG}; \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=1w -t ${IMG}; \
 	fi
 
 # Push the operator image
@@ -236,7 +236,7 @@ bundle-build: bundle
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
 		-t bundle . ; \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=2w \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=1w \
 		-t bundle . ; \
 	fi
 

--- a/trex-container-app/Makefile
+++ b/trex-container-app/Makefile
@@ -37,7 +37,7 @@ build-server: server-dependencies
 	if [ -n "$(RELEASE)" ]; then \
 	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(VERSION)" $(CONTAINER_ARGS); \
 	else \
-	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=2w  -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
+	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=1w  -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
 	fi
 
 .PHONY: build-app # Build TRex App
@@ -45,7 +45,7 @@ build-app: app-dependencies
 	if [ -n "$(RELEASE)" ]; then \
 	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(VERSION)" $(CONTAINER_ARGS); \
 	else \
-	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=2w  -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
+	$(CONTAINER_CLI) build $(@:build-%=%) -f $(@:build-%=%)/Dockerfile --label quay.expires-after=1w  -t "$(REGISTRY)/$(ORG)/trex-container-$(@:build-%=%):v$(TAG)" $(CONTAINER_ARGS); \
 	fi
 
 .PHONY: push-all # Push ALL images

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -128,7 +128,7 @@ operator-build: ensure_digests
 	if [ -n "$(RELEASE)" ]; then \
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG}  -t ${REL_IMG} ;\
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=2w -t ${IMG} ;\
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . --label quay.expires-after=1w -t ${IMG} ;\
 	fi
 
 # Push the operator image
@@ -240,7 +240,7 @@ bundle-build: bundle
 	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
 		-t bundle . ; \
 	else \
-	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=2w \
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile --label quay.expires-after=1w \
 		-t bundle . ; \
 	fi
 


### PR DESCRIPTION
We had troubles with registry disk space, and there are PRs where we generate a lot of intermediate images that remains 2 weeks in the registry. Reducing this expiration time to 1 week to avoid storage issues in the registry.