### PR TITLE
Remove references to nfv-example-cnf-deploy repo

### DIFF
--- a/nfv-example-cnf-index/README.md
+++ b/nfv-example-cnf-index/README.md
@@ -1,5 +1,5 @@
 # nfv-example-cnf-index
 
-This repository builds an index image that includes the [Example cnf operators](https://github.com/openshift-kni/example-cnf) used by the [example-cnf](https://github.com/rh-nfv-int/nfv-example-cnf-deploy).
+This repository builds an index image that includes the [Example cnf operators](https://github.com/openshift-kni/example-cnf) used by the [example_cnf_deploy role](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/example_cnf_deploy/README.md).
 
 The [CHANGELOG](./CHANGELOG.md) includes the information about the version of the image as well as the operators and their versions included in the image.

--- a/trex-container-app/app/scripts/trex-wrapper
+++ b/trex-container-app/app/scripts/trex-wrapper
@@ -38,7 +38,7 @@ fi
 
 if [ ! -z ${TREX_PROFILE_NAME} ]; then
     if [ -f "/opt/trexprofile/content" ]; then
-        # ConfigMap created by nfv-example-cnf-deploy ansible scripts
+        # ConfigMap created by example_cnf_deploy Ansible role from redhatci.ocp collection
         ln -s /opt/trexprofile/content "${HOME}/${TREX_PROFILE_NAME}"
     elif [ -f "/opt/trexprofile/${TREX_PROFILE_NAME}" ]; then
         # ConfigMap created by oc/kubectl cli


### PR DESCRIPTION
Replace it with references to the new redhatci.ocp collection role, example_cnf_deploy