### PR TITLE
Update securityContext fields of testing pods for runAsNonRoot user check

### DIFF
--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -23,7 +23,7 @@ LABEL name="NFV Example CNF Application" \
 COPY licenses /licenses
 
 # Create custom user to avoid using root account
-RUN useradd example-cnf
+RUN useradd example-cnf -u 56560
 
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf

--- a/testpmd-container-app/listener/Dockerfile
+++ b/testpmd-container-app/listener/Dockerfile
@@ -22,7 +22,7 @@ USER root
 RUN pip3 install kubernetes
 
 # Create custom user to avoid using root account
-RUN useradd example-cnf
+RUN useradd example-cnf -u 56560
 
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -23,7 +23,7 @@ LABEL name="NFV Example Testpmd LB Application" \
 COPY licenses /licenses
 
 # Create custom user to avoid using root account
-RUN useradd example-cnf
+RUN useradd example-cnf -u 56560
 
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf

--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -45,6 +45,9 @@ spec:
                 - cnf-app
                 - pkt-gen
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 56560
       serviceAccountName: loadbalancer-account
 {% if runtime_class_name is defined and runtime_class_name|length %}
       runtimeClassName: "{{ runtime_class_name }}"
@@ -78,6 +81,9 @@ spec:
         image: "{{ image_testpmd }}"
         imagePullPolicy: "{{ image_pull_policy }}"
         securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}
@@ -157,6 +163,10 @@ spec:
           containerPort: 8096
         image: "{{ image_listener }}"
         imagePullPolicy: "{{ image_pull_policy }}"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
         resources:
           limits:
             memory: "512Mi"

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -46,6 +46,9 @@ spec:
                 values:
                 - lb-app
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 56560
       serviceAccountName: testpmd-account
 {% if runtime_class_name is defined and runtime_class_name | length %}
       runtimeClassName: "{{ runtime_class_name }}"
@@ -61,6 +64,9 @@ spec:
         image: "{{ image_testpmd }}"
         imagePullPolicy: "{{ image_pull_policy }}"
         securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -33,7 +33,7 @@ ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
 # Create custom user to avoid using root account
-RUN useradd example-cnf
+RUN useradd example-cnf -u 56560
 
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -61,7 +61,7 @@ ENV TREX_DIR="/opt/trex/trex-core/scripts"
 ENV TRAFFICGEN_DIR="/opt/trafficgen"
 
 # Create custom user to avoid using root account
-RUN useradd example-cnf
+RUN useradd example-cnf -u 56560
 
 # This is to be able to manage some files that belong to root account
 RUN usermod -a -G root example-cnf

--- a/trex-operator/roles/app/templates/job.yml
+++ b/trex-operator/roles/app/templates/job.yml
@@ -16,6 +16,9 @@ spec:
 {% endif %}
     spec:
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 56560
       serviceAccountName: trex-app-account
 {% if runtime_class_name is defined and runtime_class_name | length %}
       runtimeClassName: "{{ runtime_class_name }}"
@@ -24,6 +27,10 @@ spec:
       - name: trex-app
         image: "{{ image_app }}"
         imagePullPolicy: "{{ image_pull_policy }}"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/trex-operator/roles/server/templates/deployment.yml
+++ b/trex-operator/roles/server/templates/deployment.yml
@@ -58,6 +58,9 @@ spec:
                 - cnf-app
 {% endif %}
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 56560
       serviceAccountName: trex-server-account
 {% if runtime_class_name is defined and runtime_class_name | length %}
       runtimeClassName: "{{ runtime_class_name }}"
@@ -79,6 +82,9 @@ spec:
         - name: "http-probe"
           containerPort: 8096
         securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}
@@ -151,6 +157,10 @@ spec:
       - name: trex-app
         image: "{{ image_app }}"
         imagePullPolicy: "{{ image_pull_policy }}"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 56560
+          #readOnlyRootFilesystem: true
         resources:
           limits:
             memory: "756Mi"


### PR DESCRIPTION
Similarly to what was done for https://github.com/openshift-kni/example-cnf/pull/80 in controller-manager, now this is required for pods under test too. Addressing the following test cases:

- access-control-security-context-run-as-non-root-user-check

I've added readOnly feature as commented, just to test it in a separate PR, so that we will address access-control-security-context-read-only-file-system test

- [x] Passed job - https://www.distributed-ci.io/jobs/850d180f-8dad-4dab-ba1b-66dec6f455db/jobStates