### PR TITLE
Use readOnlyRootFilesystem securityContext in data plane pods

### DIFF
--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -35,6 +35,7 @@ RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
 RUN mkdir -p /usr/local/bin/example-cnf
 RUN chmod 750 /usr/local/bin/example-cnf
 RUN chown example-cnf /usr/local/bin/example-cnf
+RUN mkdir /usr/local/bin/example-cnf/run
 
 # Create some support folders that will be needed during execution
 RUN mkdir -p /var/log/testpmd

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -79,7 +79,7 @@ RXD=${rx_descriptors:=1024}
 TXD=${tx_descriptors:=1024}
 STATS_PERIOD=${stats_period:=1}
 
-RUN="/usr/local/bin/example-cnf/testpmd-run"
+RUN="/usr/local/bin/example-cnf/run/testpmd-run"
 CMD="/usr/local/bin/example-cnf/testpmd"
 CMD="${CMD} -l $LCORES --in-memory $PCI --socket-mem ${SOCKET_MEM} -n ${MEMORY_CHANNELS} --proc-type auto --file-prefix pg"
 CMD="${CMD} --"
@@ -98,7 +98,7 @@ function sig_term() {
 trap sig_term SIGTERM
 
 if [[ $RUN_APP == "1" ]]; then
-    sudo /usr/local/bin/example-cnf/testpmd-run
+    sudo /usr/local/bin/example-cnf/run/testpmd-run
 else
     sleep infinity
 fi

--- a/testpmd-container-app/testpmd/Dockerfile
+++ b/testpmd-container-app/testpmd/Dockerfile
@@ -35,6 +35,7 @@ RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
 RUN mkdir -p /usr/local/bin/example-cnf
 RUN chmod 750 /usr/local/bin/example-cnf
 RUN chown example-cnf /usr/local/bin/example-cnf
+RUN mkdir /usr/local/bin/example-cnf/run
 
 # Create some support folders that will be needed during execution
 RUN mkdir -p /var/log/testpmd

--- a/testpmd-container-app/testpmd/scripts/testpmd-wrapper
+++ b/testpmd-container-app/testpmd/scripts/testpmd-wrapper
@@ -83,7 +83,7 @@ else
 fi
 
 STATS_PERIOD=${stats_period:=1}
-RUN="/usr/local/bin/example-cnf/testpmd-run"
+RUN="/usr/local/bin/example-cnf/run/testpmd-run"
 CMD="/usr/local/bin/example-cnf/testpmd"
 CMD="${CMD} -l $LCORES"
 CMD="${CMD} $PCI"
@@ -109,7 +109,7 @@ function sig_term() {
 trap sig_term SIGTERM
 
 if [[ $RUN_APP == "1" ]]; then
-    sudo /usr/local/bin/example-cnf/testpmd-run
+    sudo /usr/local/bin/example-cnf/run/testpmd-run
 else
     sleep infinity
 fi

--- a/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
+++ b/testpmd-lb-operator/roles/loadbalancer/templates/deployment.yml
@@ -83,7 +83,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}
@@ -112,6 +112,12 @@ spec:
           mountPath: /var/log/testpmd
         - name: lib-dir
           mountPath: /var/lib/testpmd
+        - name: exec-dir
+          mountPath: /usr/local/bin/example-cnf/run
+        - name: dpdk-dir
+          mountPath: /var/run/dpdk
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -166,7 +172,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
         resources:
           limits:
             memory: "512Mi"
@@ -179,6 +185,12 @@ spec:
           mountPath: /var/log/testpmd
         - name: lib-dir
           mountPath: /var/lib/testpmd
+        - name: exec-dir
+          mountPath: /usr/local/bin/example-cnf/run
+        - name: dpdk-dir
+          mountPath: /var/run/dpdk
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -233,4 +245,10 @@ spec:
       - name: log-dir
         emptyDir: {}
       - name: lib-dir
+        emptyDir: {}
+      - name: exec-dir
+        emptyDir: {}
+      - name: dpdk-dir
+        emptyDir: {}
+      - name: tmp
         emptyDir: {}

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -66,7 +66,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}
@@ -95,6 +95,12 @@ spec:
           mountPath: /var/log/testpmd
         - name: lib-dir
           mountPath: /var/lib/testpmd
+        - name: exec-dir
+          mountPath: /usr/local/bin/example-cnf/run
+        - name: dpdk-dir
+          mountPath: /var/run/dpdk
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -157,4 +163,10 @@ spec:
       - name: log-dir
         emptyDir: {}
       - name: lib-dir
+        emptyDir: {}
+      - name: exec-dir
+        emptyDir: {}
+      - name: dpdk-dir
+        emptyDir: {}
+      - name: tmp
         emptyDir: {}

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -69,9 +69,14 @@ RUN usermod -a -G root example-cnf
 # Allow example-cnf to use sudo permissions without asking for password
 RUN echo -e "example-cnf\tALL=(ALL)\tNOPASSWD: ALL" > /etc/sudoers.d/example-cnf
 
-# Make sure /etc/trex_cfg.yaml is present and with proper permissions
-RUN touch /etc/trex_cfg.yaml
-RUN chmod 664 /etc/trex_cfg.yaml
+# Create a folder managed by the custom user to place the config files to launch
+RUN mkdir -p /usr/local/bin/example-cnf
+RUN chmod 750 /usr/local/bin/example-cnf
+RUN chown example-cnf /usr/local/bin/example-cnf
+
+# Make sure trex_cfg.yaml is present in the proper folder and with proper permissions
+RUN touch /usr/local/bin/example-cnf/trex_cfg.yaml
+RUN chmod 664 /usr/local/bin/example-cnf/trex_cfg.yaml
 
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin

--- a/trex-container-app/server/scripts/trex-cfg-configure
+++ b/trex-container-app/server/scripts/trex-cfg-configure
@@ -31,7 +31,7 @@ port_obj_l2_template = {
     "src_mac": ""
 }
 
-CFG_FILE = "/etc/trex_cfg.yaml"
+CFG_FILE = "/usr/local/bin/example-cnf/trex_cfg.yaml"
 
 
 def main():

--- a/trex-container-app/server/scripts/trex-server
+++ b/trex-container-app/server/scripts/trex-server
@@ -19,7 +19,7 @@ n=0
 until [ "$n" -ge 5 ]
 do
    cd /opt/trex/trex-core/scripts
-   ./_t-rex-64 -i --no-hw-flow-stat -c $CORE_COUNT
+   ./_t-rex-64 --cfg /usr/local/bin/example-cnf/trex_cfg.yaml -i --no-hw-flow-stat -c $CORE_COUNT
    n=$((n+1))
    sleep 5
 done

--- a/trex-container-app/server/scripts/trex-wrapper
+++ b/trex-container-app/server/scripts/trex-wrapper
@@ -41,8 +41,8 @@ fi
 
 # Read the number of cores from the trex cfg
 # It is required as input via -c arg (for binary_search scripts of trafficgen)
-CORE_COUNT_CFG=$(grep ' c: ' /etc/trex_cfg.yaml | cut -d: -f2 | xargs)
-NUM_PORTS=$(grep ' port_limit: ' /etc/trex_cfg.yaml | cut -d: -f 2 | xargs)
+CORE_COUNT_CFG=$(grep ' c: ' /usr/local/bin/example-cnf/trex_cfg.yaml | cut -d: -f2 | xargs)
+NUM_PORTS=$(grep ' port_limit: ' /usr/local/bin/example-cnf/trex_cfg.yaml | cut -d: -f 2 | xargs)
 
 CORE_COUNT=${trex_core_count:=$CORE_COUNT_CFG}
 # TREX_CPU env will be set on the pod spec with number of required cores

--- a/trex-operator/roles/app/templates/job.yml
+++ b/trex-operator/roles/app/templates/job.yml
@@ -30,10 +30,16 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
         volumeMounts:
         - name: varlog
           mountPath: /var/log
+        - name: log-dir
+          mountPath: /var/log/trex
+        - name: tmp-dir
+          mountPath: /tmp
+        - name: dpdk-dir
+          mountPath: /var/run/dpdk
 {% if trex_profile_config_map %}
         - name: profile
           mountPath: /opt/trexprofile
@@ -106,6 +112,12 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: varlog
+        emptyDir: {}
+      - name: log-dir
+        emptyDir: {}
+      - name: tmp-dir
+        emptyDir: {}
+      - name: dpdk-dir
         emptyDir: {}
 {% if trex_profile_config_map %}
       - name: profile

--- a/trex-operator/roles/server/templates/deployment.yml
+++ b/trex-operator/roles/server/templates/deployment.yml
@@ -84,7 +84,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
 {% if privileged %}
           privileged: true
 {% else %}
@@ -109,6 +109,10 @@ spec:
         volumeMounts:
         - name: hugepage
           mountPath: /dev/hugepages
+        - name: config-dir
+          mountPath: /usr/local/bin/example-cnf
+        - name: dpdk-dir
+          mountPath: /var/run/dpdk
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -160,7 +164,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 56560
-          #readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: true
         resources:
           limits:
             memory: "756Mi"
@@ -216,3 +220,7 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
+      - name: config-dir
+        emptyDir: {}
+      - name: dpdk-dir
+        emptyDir: {}


### PR DESCRIPTION
- This intends to fix access-control-security-context-read-only-file-system certsuite test for data plane pods, since this has to fail in controller-manager pods because they require it for reconciliation loop.
- Apart from including readOnlyRootFilesystem securityContext field, it's also needed to define volumes for the directories where there may be modified or newly created files during execution.

Tests:

- [x] Test with loadbalancer only - https://www.distributed-ci.io/jobs/8a1c873b-b672-4134-b2d1-cfecfeabbd95/tests/b5fd50fa-0f4a-46da-87ab-fc48b899bf0b?testcase=access-control-security-context-read-only-file-system
- [x] Test with the other pods - https://www.distributed-ci.io/jobs/fcbf86c6-bdd3-4c9b-9fda-d372b2016f41/tests/75cdc139-9ee7-4ea1-821a-c4dd5e155a59?testcase=access-control-security-context-read-only-file-system