### PR TITLE
Tune socket-mem testpmd parameter based on the NUMA node

### DIFF
--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -71,6 +71,12 @@ for item in "${ETH_PEER_LIST[@]}"; do
 done
 
 SOCKET_MEM=${socket_mem:=1024}
+# We are always assuming that testpmd is allocated in numa0 node, but if using numa1, SOCKET_MEM has to be reordered to specificy
+# 0 memory for socket 0 and SOCKET_MEM memory for socket 1
+NUMA_NODE=$(numactl --show | grep nodebind |  awk '{print $2}')
+if [ $NUMA_NODE -ne 0 ]; then
+    SOCKET_MEM="0,${SOCKET_MEM}"
+fi
 MEMORY_CHANNELS=${memory_channels:=4}
 FORWARDING_CORES=${forwarding_cores:=2}
 RXQ=${rx_queues:=1}


### PR DESCRIPTION
In Dallas, all testpmd pods are placed in numa0 node, however, in BOS2, numa1 node is used instead.

There's a testpmd parameter, `socket-mem`, that defines the memory to be allocated on each socket (NUMA node), and it's a comma-separated list. Right now, we provide only one term, that is always linked to numa0. But if using numa1, we should provide a second term to really allocate the hugepages in the numa1 node.

Using `numactl` command installed on testpmd to detect in which NUMA node the pod is allocated (we use single-numa-node performace profile setup), so that we can define the proper socket-mem value

- [x] Dallas (uses numa0) - https://www.distributed-ci.io/jobs/543882e1-5799-4250-8b21-b0de06c2fcaa/jobStates
- [x] BOS2 (uses numa1) - https://www.distributed-ci.io/jobs/81335748-bc06-4db3-959a-dd888bae660b/jobStates?sort=date