### PR TITLE
Remove trademark

### DIFF
--- a/cnf-app-mac-operator/Dockerfile
+++ b/cnf-app-mac-operator/Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL name="NFV Example CNF App MAC Operator" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.20" \
       release="v0.2.20" \

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -13,7 +13,7 @@ RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 FROM quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 
 LABEL name="NFV Example CNF Application" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.13" \
       release="v0.2.13" \

--- a/testpmd-operator/Dockerfile
+++ b/testpmd-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:v1.35.0
 
 LABEL name="NFV Example CNF Application Opertor" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.20" \
       release="v0.2.20" \

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -8,7 +8,7 @@ RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 FROM registry.access.redhat.com/ubi8/python-311:latest
 
 LABEL name="NFV Example TRexApp Application" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.13" \
       release="v0.2.13" \

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -9,7 +9,7 @@ RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 FROM quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1
 
 LABEL name="NFV Example TRexServer Application" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.13" \
       release="v0.2.13" \

--- a/trex-operator/Dockerfile
+++ b/trex-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:v1.35.0
 
 LABEL name="NFV Example CNF TRex Operator" \
-      maintainer="telcoci@redhat.com" \
+      maintainer="telcoci" \
       vendor="fredco" \
       version="v0.2.22" \
       release="v0.2.22" \


### PR DESCRIPTION
HasRequiredLabel check is failing as it validates that container labels do not contain references to Red Hat. See: https://github.com/redhat-openshift-ecosystem/openshift-preflight/commit/ee9611b2a15333c9184b9cf51485fcc8f62b9f1a#diff-7f30e90a5ee0fb5b3ef312b3676e6894d2e027a6ee178e3cd3fd13af68f15e8eR44
