### PR TITLE
Include reduced mode in testpmd

### DIFF
--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.14
+VERSION         ?= 0.2.15
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.14"}
+TAG=${TAG:-"v0.2.15"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -15,8 +15,8 @@ FROM quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 LABEL name="NFV Example CNF Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.14" \
-      release="v0.2.14" \
+      version="v0.2.15" \
+      release="v0.2.15" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -8,6 +8,7 @@ set -ex
 echo "Running testpmd"
 
 RUN_APP=${run_app:=1}
+REDUCED_MODE=${reduced_mode:=0}
 
 LOG_DIR="/var/log/testpmd"
 [ -d $LOG_DIR ] || mkdir -p $LOG_DIR
@@ -77,13 +78,25 @@ NUMA_NODE=$(numactl --show | grep nodebind |  awk '{print $2}')
 if [ $NUMA_NODE -ne 0 ]; then
     SOCKET_MEM="0,${SOCKET_MEM}"
 fi
-MEMORY_CHANNELS=${memory_channels:=4}
+MEMORY_CHANNELS=${memory_channels:=6}
 FORWARDING_CORES=${forwarding_cores:=2}
 RXQ=${rx_queues:=1}
 TXQ=${tx_queues:=1}
 RXD=${rx_descriptors:=1024}
 TXD=${tx_descriptors:=1024}
 STATS_PERIOD=${stats_period:=1}
+
+# modify RXD and TXD (x2)
+# If reduced mode is selected:
+# - Manipulate the cores to use to just use the 2nd core with its sibling (note that, in interactive
+#   node, we should also select the 1st core without its sibling, to allocate three cores, but we don't
+#   use interactive mode in the automation, so this is omitted)
+# - Double RXD and TXD values
+if [[ $REDUCED_MODE != "0" ]]; then
+    LCORES="${CORES_ARR[1]}","${CORES_ARR[$((TESTPMD_CPU_COUNT/2+1))]}"
+    RXD=$((RXD*2))
+    TXD=$((TXD*2))
+fi
 
 RUN="/usr/local/bin/example-cnf/run/testpmd-run"
 CMD="/usr/local/bin/example-cnf/testpmd"

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -93,6 +93,8 @@ STATS_PERIOD=${stats_period:=1}
 #   use interactive mode in the automation, so this is omitted)
 # - Double RXD and TXD values
 if [[ $REDUCED_MODE != "0" ]]; then
+    # Extract cores from numactl output, which provides all used cores, since LCORES may save them using an interval
+    CORES_ARR=($(numactl --show | grep physcpubind | cut -f2- -d ' '))
     LCORES="${CORES_ARR[1]}","${CORES_ARR[$((TESTPMD_CPU_COUNT/2+1))]}"
     RXD=$((RXD*2))
     TXD=$((TXD*2))

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -88,14 +88,12 @@ STATS_PERIOD=${stats_period:=1}
 
 # modify RXD and TXD (x2)
 # If reduced mode is selected:
-# - Manipulate the cores to use to just use the 2nd core with its sibling (note that, in interactive
-#   node, we should also select the 1st core without its sibling, to allocate three cores, but we don't
-#   use interactive mode in the automation, so this is omitted)
+# - Manipulate the cores to use to just use the 1st core (for console) and 2nd core with its sibling
 # - Double RXD and TXD values
 if [[ $REDUCED_MODE != "0" ]]; then
     # Extract cores from numactl output, which provides all used cores, since LCORES may save them using an interval
     CORES_ARR=($(numactl --show | grep physcpubind | cut -f2- -d ' '))
-    LCORES="${CORES_ARR[1]}","${CORES_ARR[$((TESTPMD_CPU_COUNT/2+1))]}"
+    LCORES="${CORES_ARR[0]}","${CORES_ARR[1]}","${CORES_ARR[$((TESTPMD_CPU_COUNT/2+1))]}"
     RXD=$((RXD*2))
     TXD=$((TXD*2))
 fi
@@ -104,7 +102,7 @@ RUN="/usr/local/bin/example-cnf/run/testpmd-run"
 CMD="/usr/local/bin/example-cnf/testpmd"
 CMD="${CMD} -l $LCORES --in-memory $PCI --socket-mem ${SOCKET_MEM} -n ${MEMORY_CHANNELS} --proc-type auto --file-prefix pg"
 CMD="${CMD} --"
-CMD="${CMD} --disable-rss --nb-cores=${FORWARDING_CORES} --rxq=${RXQ} --txq=${TXQ} --rxd=${RXD} --txd=${TXD}"
+CMD="${CMD} --nb-cores=${FORWARDING_CORES} --rxq=${RXQ} --txq=${TXQ} --rxd=${RXD} --txd=${TXD}"
 CMD="${CMD} --auto-start ${ETH_PEER} --forward-mode=mac --stats-period ${STATS_PERIOD}"
 CMD="${CMD} 2>&1 | tee /var/log/testpmd/app.log"
 echo "${CMD}" > $RUN

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.23] - 2024-12-27
+
+- Enable reduced mode
+
 ## [0.2.22] - 2024-12-12
 
 - Updated OperatorSDK to v1.38.0, kube-rbac-proxy is no longer included

--- a/testpmd-operator/Dockerfile
+++ b/testpmd-operator/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/operator-framework/ansible-operator:v1.36.1
 LABEL name="NFV Example CNF Application Opertor" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.22" \
-      release="v0.2.22" \
+      version="v0.2.23" \
+      release="v0.2.23" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION := 0.2.22
+VERSION := 0.2.23
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.

--- a/testpmd-operator/roles/testpmd/defaults/main.yml
+++ b/testpmd-operator/roles/testpmd/defaults/main.yml
@@ -17,11 +17,11 @@ size: 1
 hugepage_1gb_count: 4Gi
 memory: 1000Mi
 cpu: 6
-forwarding_cores: 4
+forwarding_cores: 2
 
 forward_mode: mac
 
-memory_channels: 4
+memory_channels: 6
 socket_memory: 1024
 
 rx_queues: 1

--- a/testpmd-operator/roles/testpmd/templates/deployment.yml
+++ b/testpmd-operator/roles/testpmd/templates/deployment.yml
@@ -126,6 +126,8 @@ spec:
           value: "{{ rx_descriptors }}"
         - name: tx_descriptors
           value: "{{ tx_descriptors }}"
+        - name: reduced_mode
+          value: "{{ reduced_mode }}"
 {% for key, value in environments.items() %}
         - name: {{ key }}
           value: "{{ value }}"

--- a/trex-container-app/app/scripts/run-trex
+++ b/trex-container-app/app/scripts/run-trex
@@ -218,6 +218,7 @@ def main():
     log.info("Starting burst...")
     log.info("Packet Size - %s" % packet_size)
     log.info("Packet Rate - %s" % packet_rate)
+    log.info("Job Duration - %s" % duration)
     if profile:
         log.info("TRex profile - %s" % profile)
     if duration == -1:


### PR DESCRIPTION
- If setting a flag in testpmd execution, reduced mode will be used, where only the 1st core (without sibling) and 2nd core and its sibling is used, also rxd and txd parameters are doubled in that case.
- Modifying some parameters to match the current scenario we're using
- Also, printing job duration in TRexApp code