### PR TITLE
Stop trex-app after duration time is reached

### DIFF
--- a/trex-container-app/app/pyfiles/trexstats.py
+++ b/trex-container-app/app/pyfiles/trexstats.py
@@ -141,9 +141,9 @@ def completed_stats(stats, warnings, port_a, port_b, profile, rate, duration):
     packets = stats[port_a]["opackets"] + stats[port_b]["opackets"]
     total_lost = lost * 100.0 / packets
 
-    log.info(f"\nPackets lost from {port_a} to {port_b}: {lost_a} packets, which is {percentage_lost_a}% packet loss")
-    log.info(f"Packets lost from {port_b} to {port_a}: {lost_b} packets, which is {percentage_lost_b}% packet loss")
-    log.info(f"Total packets lost: {lost} packets, which is {total_lost}% packet loss")
+    log.info(f"\nPackets lost from {port_a} to {port_b}: {lost_a} packets, which is {format(percentage_lost_a, '.10f')}% packet loss")
+    log.info(f"Packets lost from {port_b} to {port_a}: {lost_b} packets, which is {format(percentage_lost_b, '.10f')}% packet loss")
+    log.info(f"Total packets lost: {lost} packets, which is {format(total_lost, '.10f')}% packet loss")
 
     if warnings:
         log.info("\n\n*** test had warnings ****\n\n")

--- a/trex-container-app/app/scripts/run-trex
+++ b/trex-container-app/app/scripts/run-trex
@@ -175,9 +175,9 @@ class STLS1(object):
 
             # block until done, having a timeout that expires after reaching the specified duration (if provided)
             # with 1 second delay waiying after last packet is sent
-            if duration != -1:
+            if self.duration != -1:
                 try:
-                    self.client.wait_on_traffic(ports=self.ports, timeout=duration, rx_delay_ms=1000)
+                    self.client.wait_on_traffic(ports=self.ports, timeout=self.duration, rx_delay_ms=1000)
                 except TRexTimeoutError as e:
                     log.info("Reached timeout, job will finish")
                     log.info(e)

--- a/trex-container-app/app/scripts/run-trex
+++ b/trex-container-app/app/scripts/run-trex
@@ -173,8 +173,16 @@ class STLS1(object):
             # start monitory thread to post stats
             self.start_stats_monitor()
 
-            # block until done
-            self.client.wait_on_traffic(ports=self.ports)
+            # block until done, having a timeout that expires after reaching the specified duration (if provided)
+            # with 1 second delay waiying after last packet is sent
+            if duration != -1:
+                try:
+                    self.client.wait_on_traffic(ports=self.ports, timeout=duration, rx_delay_ms=1000)
+                except TRexTimeoutError as e:
+                    log.info("Reached timeout, job will finish")
+                    log.info(e)
+            else:
+                self.client.wait_on_traffic(ports=self.ports)
 
             trexstats.force_exit = True
 


### PR DESCRIPTION
Modify [wait_on_traffic](https://trex-tgn.cisco.com/trex/doc/cp_stl_docs/api/client_code.html#stlclient-class) behavior, so that we don't wait until all traffic is sent, stopping if timeout (equal to job duration) is reached.
Bonus: print packet loss statistics in non-scientific notation, so that it can be processed as a number in some bash script we have for analytics.

Tests:

- [x] only example-cnf execution where TRex job passes - https://www.distributed-ci.io/jobs/0d323d39-6979-4bdf-803f-8248e80870a2/jobStates?sort=date
- [x] only example-cnf execution where TRex job fails - https://www.distributed-ci.io/jobs/d431f098-008d-4b7c-a693-5d3c1ce4e75d/jobStates?sort=date
- [x] complete example-cnf execution with preflight and certsuite - https://www.distributed-ci.io/jobs/f8486b79-eee1-4a24-9696-ac1350ff18b2/jobStates?sort=date