### PR TITLE
Update DPDK and TRex versions

### DIFF
--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -394,26 +394,21 @@ EAL: Selected IOVA mode 'VA'
 EAL: 8000 hugepages of size 2097152 reserved, but no mounted hugetlbfs found for that size
 EAL: VFIO support initialized
 EAL: Using IOMMU type 1 (Type 1)
-EAL: Probe PCI driver: net_iavf (8086:154c) device: 0000:86:02.7 (socket 1)
-EAL: Probe PCI driver: net_iavf (8086:154c) device: 0000:86:03.6 (socket 1)
-TELEMETRY: No legacy callbacks, legacy socket not created
 Interactive-mode selected
 Set mac packet forwarding mode
 testpmd: create a new mbuf pool <mb_pool_1>: n=163456, size=2176, socket=1
 testpmd: preferred mempool ops selected: ring_mp_mc
 Configuring Port 0 (socket 1)
-iavf_dev_init_vlan(): Failed to update vlan offload
-iavf_dev_configure(): configure VLAN failed: -95
-iavf_set_rx_function(): request RXDID[1] in Queue[0] is legacy, set rx_pkt_burst as legacy for all queues
-
+IAVF_DRIVER: iavf_set_rx_function(): request RXDID[1] in Queue[0] is legacy, set rx_p[70/144]
+ as legacy for all queues  
+ 
 Port 0: link state change event
 
 Port 0: link state change event
 Port 0: 80:04:0F:F1:89:01
 Configuring Port 1 (socket 1)
-iavf_dev_init_vlan(): Failed to update vlan offload
-iavf_dev_configure(): configure VLAN failed: -95
-iavf_set_rx_function(): request RXDID[1] in Queue[0] is legacy, set rx_pkt_burst as legacy for all queues
+IAVF_DRIVER: iavf_set_rx_function(): request RXDID[1] in Queue[0] is legacy, set rx_pkt_burst
+ as legacy for all queues
 
 Port 1: link state change event
 
@@ -657,7 +652,7 @@ Acquiring ports [0, 1]:                                      [SUCCESS]
 
 Server Info:
 
-Server version:   v2.85 @ STL
+Server version:   v3.06 @ STL
 Server mode:      Stateless
 Server CPU:       4 x Intel(R) Xeon(R) Gold 6248R CPU @ 3.00GHz
 Ports count:      2 x 10.0Gbps @ Unknown	

--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.16
+VERSION         ?= 0.2.17
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.16"}
+TAG=${TAG:-"v0.2.17"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -1,5 +1,5 @@
 ## Build image
-FROM quay.io/rh-nfv-int/dpdk-23.11:v0.0.1 as build
+FROM quay.io/rh-nfv-int/dpdk:v0.0.1 as build
 
 ## Image to build webserver
 FROM docker.io/library/golang:1.23 as build2
@@ -15,8 +15,8 @@ FROM quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 LABEL name="NFV Example CNF Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.16" \
-      release="v0.2.16" \
+      version="v0.2.17" \
+      release="v0.2.17" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/trex-container-app/Makefile
+++ b/trex-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.15
+VERSION         ?= 0.2.16
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -10,22 +10,22 @@ FROM registry.access.redhat.com/ubi8/python-311:latest
 LABEL name="NFV Example TRexApp Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.15" \
-      release="v0.2.15" \
+      version="v0.2.16" \
+      release="v0.2.16" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 
 COPY licenses /licenses
 
-ENV TREX_VER v2.85
+ENV TREX_VER v3.06
 ENV TREX_REPO https://github.com/cisco-system-traffic-generator/trex-core.git
-ENV TRAFFICGEN_REPO https://github.com/atheurer/trafficgen
+ENV TRAFFICGEN_REPO https://github.com/perftool-incubator/bench-trafficgen
 
 USER root
 
 RUN yum install -y nc && yum clean all
 RUN mkdir -p /opt/trex && cd /opt/trex && git clone --branch ${TREX_VER}  ${TREX_REPO}
-RUN cd /opt && git clone  ${TRAFFICGEN_REPO}
+RUN cd /opt && git clone ${TRAFFICGEN_REPO} && mv bench-trafficgen/trafficgen . && rm -rf bench-trafficgen
 RUN pip3 install pyyaml kubernetes
 
 ENV PYTHONPATH="/opt/trex/trex-core/scripts/automation/trex_control_plane/interactive"

--- a/trex-container-app/build.sh
+++ b/trex-container-app/build.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
-TAG="${TAG:-v0.2.15}"
+TAG="${TAG:-v0.2.16}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -11,16 +11,16 @@ FROM quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1
 LABEL name="NFV Example TRexServer Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.15" \
-      release="v0.2.15" \
+      version="v0.2.16" \
+      release="v0.2.16" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 
 COPY licenses /licenses
 
-ENV TREX_VER v2.85
+ENV TREX_VER v3.06
 ENV TREX_REPO https://github.com/cisco-system-traffic-generator/trex-core.git
-ENV TRAFFICGEN_REPO https://github.com/atheurer/trafficgen
+ENV TRAFFICGEN_REPO https://github.com/perftool-incubator/bench-trafficgen
 
 # Install prerequisite packages from UBI repos
 RUN dnf install -y \
@@ -49,10 +49,9 @@ RUN dnf install -y \
 RUN mkdir -p /opt/trex && cd /opt/trex && git clone --branch ${TREX_VER} ${TREX_REPO}
 RUN cd /opt/trex/trex-core/linux_dpdk && \
     ./b configure --no-mlx --no-bxnt --new-memory && \
-    cp dpdk_config.h /opt/trex/trex-core/src/ && \
     ./b build
 
-RUN cd /opt && git clone ${TRAFFICGEN_REPO}
+RUN cd /opt && git clone ${TRAFFICGEN_REPO} && mv bench-trafficgen/trafficgen . && rm -rf bench-trafficgen
 RUN pip3 install kubernetes
 
 ENV PYTHONPATH="/opt/trex/trex-core/scripts/automation/trex_control_plane/interactive"

--- a/utils/README.md
+++ b/utils/README.md
@@ -9,12 +9,12 @@ Here, you can find some utilities included in Example CNF to extend the function
 ```
 # build images
 $ cd support-images
-$ podman build dpdk-23.11 -f dpdk-23.11/Dockerfile -t "quay.io/rh-nfv-int/dpdk-23.11:v0.0.1"
+$ podman build dpdk -f dpdk/Dockerfile -t "quay.io/rh-nfv-int/dpdk:v0.0.1"
 $ podman build ubi8-base-testpmd -f ubi8-base-testpmd/Dockerfile -t "quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1"
 $ podman build ubi8-base-trex -f ubi8-base-trex/Dockerfile -t "quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1"
 
 # push images (to quay.io/rh-nfv-int)
-$ podman push quay.io/rh-nfv-int/dpdk-23.11:v0.0.1
+$ podman push quay.io/rh-nfv-int/dpdk:v0.0.1
 $ podman push quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 $ podman push quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1
 ```

--- a/utils/support-images/dpdk/Dockerfile
+++ b/utils/support-images/dpdk/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-ENV DPDK_VER=23.11
+ENV DPDK_VER=24.11
 ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
 
 # Install prerequisite packages


### PR DESCRIPTION
- Bump DPDK to latest LTS version - 24.11
- Bump TRex to latest release - v3.06
- Use https://github.com/perftool-incubator/bench-trafficgen repo since https://github.com/atheurer/trafficgen is deprecated

Tests

- [x] Troubleshooting mode, to test all commands manually - https://www.distributed-ci.io/jobs/96d781a2-0826-4756-9faa-e48e94fc42c9/jobStates
- [x] Full pipeline in automated mode - https://www.distributed-ci.io/jobs/66fac749-4a14-416e-95b0-f7a1e7801ef3/jobStates?sort=date

