### PR TITLE
Support for Mellanox interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ TRex -- (example-cnf-net1|2) -- CNF Application
 
 You can also provide IP addresses if requiring L3 connectivity. This is mandatory for Grout, and optional for TestPMD, since TestPMD acts in MAC forwarding mode, so it will ignore all network headers above L2.
 
+### NIC support
+
+The deployment is fully compliant with Intel NICs.
+
+However, we found difficulties when trying to test Mellanox NICs with TRex pod. With the current setup, when launching TRex, it's not able to find the requested interfaces.
+
+According to TRex documentation, [OFED driver](https://trex-tgn.cisco.com/trex/doc/trex_appendix_mellanox.html) should be required. Its deployment in an OpenShift cluster is out of the scope of this project and has not been fully validated, so it's not guaranteed that Mellanox NICs can be used with the TRex pod. Only DPDK-related pods (Grout and TestPMD) can be deployed without any problem.
+
 ## Traffic Flow
 
 Traffic flow is the following:

--- a/grout-container-app/cnfapp/Dockerfile
+++ b/grout-container-app/cnfapp/Dockerfile
@@ -1,7 +1,7 @@
 ## Image to build webserver
-FROM docker.io/library/golang:1.23 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as build
 
-WORKDIR /utils
+WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
@@ -53,7 +53,7 @@ RUN chmod 750 /var/log/grout
 RUN chown example-cnf /var/log/grout
 
 # Copy scripts
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
+COPY --chmod=550 --from=build /opt/app-root/src/webserver /usr/local/bin/webserver
 COPY --chmod=550 scripts/grout-wrapper /usr/local/bin/example-cnf/grout-wrapper
 COPY --chmod=550 scripts/retrieve-grout-ip-addresses /usr/local/bin/example-cnf/retrieve-grout-ip-addresses
 

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -2,9 +2,9 @@
 FROM quay.io/rh-nfv-int/dpdk:v0.0.1 as build
 
 ## Image to build webserver
-FROM docker.io/library/golang:1.23 as build2
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as build2
 
-WORKDIR /utils
+WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
@@ -43,7 +43,7 @@ RUN chmod 750 /var/log/testpmd
 RUN chown example-cnf /var/log/testpmd
 
 # Copy scripts
-COPY --chmod=550 --from=build2 /utils/webserver /usr/local/bin/webserver
+COPY --chmod=550 --from=build2 /opt/app-root/src/webserver /usr/local/bin/webserver
 COPY --chmod=550 --from=build /usr/local/bin/dpdk-testpmd /usr/local/bin/example-cnf/testpmd
 COPY --chmod=550 scripts/testpmd-wrapper /usr/local/bin/example-cnf/testpmd-wrapper
 

--- a/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
+++ b/testpmd-container-app/cnfapp/scripts/testpmd-wrapper
@@ -45,13 +45,17 @@ if [ -f /sys/fs/cgroup/cpuset/cpuset.cpus ]; then
 elif [ -f /sys/fs/cgroup/cpuset.cpus ]; then
     # Applied to latest OCP 4.16 nightlies starting from 4.16.0 ec.5
     LCORES=$(cat /sys/fs/cgroup/cpuset.cpus)
+elif [ -f /proc/1/status ]; then
+    # Applied when using a privileged pod, since /sys/fs/cgroup directory is overriden with host configuration
+    # Extract the list of CPUs from /proc/1/status file
+    LCORES=$(cat /proc/1/status | grep Cpus_allowed_list |  awk '{print $2}')
 else
-    echo "Could not find file to extract cores, existing.."
+    echo "Could not find file to extract cores, exiting..."
     exit 1
 fi
 
 if [ -z $LCORES ]; then
-    echo "Could not find cores, existing.."
+    echo "Could not find cores, exiting..."
     exit 1
 fi
 

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/golang:1.23 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as build
 
-WORKDIR /utils
+WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
@@ -45,7 +45,7 @@ RUN chown example-cnf:example-cnf /var/log/trex
 
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin/
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
+COPY --chmod=550 --from=build /opt/app-root/src/webserver /usr/local/bin/webserver
 COPY --chmod=550 pyfiles /opt/pyfiles/
 
 # Move to the custom user

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/golang:1.23 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as build
 
-WORKDIR /utils
+WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
@@ -46,9 +46,10 @@ RUN dnf install -y \
     vim \
     && dnf clean all
 
+# Install TRex
 RUN mkdir -p /opt/trex && cd /opt/trex && git clone --branch ${TREX_VER} ${TREX_REPO}
 RUN cd /opt/trex/trex-core/linux_dpdk && \
-    ./b configure --no-mlx --no-bxnt --new-memory && \
+    ./b configure --no-bnxt --new-memory && \
     ./b build
 
 RUN cd /opt && git clone ${TRAFFICGEN_REPO} && mv bench-trafficgen/trafficgen . && rm -rf bench-trafficgen
@@ -79,7 +80,7 @@ RUN chmod 664 /usr/local/bin/example-cnf/trex_cfg.yaml
 
 # Copy scripts
 COPY --chmod=550 scripts /usr/local/bin
-COPY --chmod=550 --from=build /utils/webserver /usr/local/bin/webserver
+COPY --chmod=550 --from=build /opt/app-root/src/webserver /usr/local/bin/webserver
 
 # Move to the custom user
 USER example-cnf

--- a/trex-container-app/server/scripts/trex-server
+++ b/trex-container-app/server/scripts/trex-server
@@ -19,7 +19,7 @@ n=0
 until [ "$n" -ge 5 ]
 do
    cd /opt/trex/trex-core/scripts
-   ./_t-rex-64 --cfg /usr/local/bin/example-cnf/trex_cfg.yaml -i --no-hw-flow-stat -c $CORE_COUNT
+   ./_t-rex-64 --cfg /usr/local/bin/example-cnf/trex_cfg.yaml --no-ofed-check -i --no-hw-flow-stat -c $CORE_COUNT
    n=$((n+1))
    sleep 5
 done

--- a/utils/support-images/ubi8-base-trex/Dockerfile
+++ b/utils/support-images/ubi8-base-trex/Dockerfile
@@ -4,6 +4,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN dnf install -y \
     numactl \
     numactl-devel \
+    rdma-core \
+    rdma-core-devel \
     nfs-utils \
     perf \
     tcpdump \


### PR DESCRIPTION
- Include some more packages (e.g. rdma-core and rdma-core devel), which include libibverbs and libmlx5 libraries which are eventually needed by Mellanox NICs
- Adapting TestPMD to retrieve the assigned CPUs from a correct file when we're using privileged mode (required for Mellanox).
- Include Mellanox libraries when compiling TRex, update `no-bnxt` flag, which was incorrect
- Use `--no-ofed-check` when running TRex
- Suffered from [outages](https://github.com/openshift-kni/example-cnf/actions/runs/14733308477/job/41352905759?pr=122) with docker.io rate limit during testing, moving to Red Hat registry instead for the golang image.
- Include comments about Mellanox support for DPDK and TRex

build-depends: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/661
build-depends: https://github.com/dci-labs/example-cnf-config/pull/121

- [x] Test with Mellanox cards - https://www.distributed-ci.io/jobs/69325e32-56e6-4eb8-9a5d-3faee1485df4/jobStates

Tested the ping between the grout pod created by the automation and another grout instance created manually, since TRex cannot be used with Mellanox cards:

```
grout# ping 192.168.104.60
reply from 192.168.104.60: icmp_seq=0 ttl=64 time=0.025 ms
reply from 192.168.104.60: icmp_seq=1 ttl=64 time=0.014 ms
grout# show trace count 50
--------- 13:56:50.673914819 cpu 3 ---------
control_input:
icmp_local_send:
ip_output: 192.168.104.62 > 192.168.104.60 ttl=64 proto=ICMP(1)
eth_output: 00:11:22:33:00:01 > 80:0a:0f:f1:89:01 type=IP(0x0800) iface=p0
port_tx: port=0 queue=2

--------- 13:56:50.673914819 cpu 1 ---------
port_rx: port=0 queue=1
eth_input: 80:0a:0f:f1:89:01 > 00:11:22:33:00:01 type=IP(0x0800) iface=p0
ip_input: 192.168.104.60 > 192.168.104.62 ttl=64 proto=ICMP(1)
ip_input_local:
icmp_input: echo reply id=25 seq=1
control_output:
```

- [x] Test with Intel cards - https://www.distributed-ci.io/jobs/c9012d79-9651-4511-84e0-0cd58f4aa751/jobStates

Automation with grout worked in a regular cluster. Changes were not affecting the default behavior.