### PR TITLE
Move Grout to v0.10.2

### DIFF
--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -698,7 +698,7 @@ $ oc rsh -n example-cnf deployment/grout-app
 
 # check the script that has been created by the automation
 sh-4.4$ cat /usr/local/bin/example-cnf/run/config-grout
-grcli -f /usr/local/bin/example-cnf/run/grout.init 2>&1 | tee /var/log/grout/app.log
+grcli -f /usr/local/bin/example-cnf/run/grout.init -s /usr/local/bin/example-cnf/run/grout.sock 2>&1 | tee /var/log/grout/app.log
 
 # check the config file to be applied
 sh-4.4$ cat /usr/local/bin/example-cnf/run/grout.init
@@ -712,10 +712,10 @@ add ip address 172.16.21.60/24 iface p1
 sh-4.4$ sudo /usr/local/bin/example-cnf/run/config-grout
 
 # clear statistics
-sh-4.4$ sudo grcli clear stats
+sh-4.4$ sudo grcli -s /usr/local/bin/example-cnf/run/grout.sock clear stats
 
 # print statistics
-sh-4.4$ sudo grcli show stats software
+sh-4.4$ sudo grcli -s /usr/local/bin/example-cnf/run/grout.sock show stats software
 NODE                            CALLS  PACKETS  PKTS/CALL  CYCLES/CALL     CYCLES/PKT
 port_rx                  109805489408     2104        0.0         49.2   2567088141.0
 control_input            109805489408       39        0.0         22.6  63637321574.4

--- a/grout-container-app/cnfapp/Dockerfile
+++ b/grout-container-app/cnfapp/Dockerfile
@@ -19,15 +19,8 @@ LABEL name="NFV Example CNF Grout Application" \
 
 COPY licenses /licenses
 
-ENV GROUT_VER v0.9.1
+ENV GROUT_VER v0.10.2
 ENV GROUT_RPM https://github.com/DPDK/grout/releases/download/${GROUT_VER}/grout.x86_64.rpm
-
-# Install prerequisite packages
-RUN dnf install -y \
-    python39 \
-    python3-pip \
-    && dnf clean all
-RUN pip3 install kubernetes
 
 # check latest release from https://github.com/DPDK/grout/releases
 RUN dnf -y install ${GROUT_RPM}

--- a/grout-container-app/cnfapp/README.md
+++ b/grout-container-app/cnfapp/README.md
@@ -37,23 +37,25 @@ add ip address 172.16.16.60/24 iface p0
 add ip address 172.16.21.60/24 iface p1
 ```
 
-The file created by the automation to launch the Grout configuration is saved under `/usr/local/bin/example-cnf/run/config-grout`, and it has the following content:
+The file created by the automation to launch the Grout configuration is saved under `/usr/local/bin/example-cnf/run/grout.sock`, and it has the following content:
 
 ```
 sh-4.4$ cat config-grout
-grcli -f /usr/local/bin/example-cnf/run/grout.init 2>&1 | tee /var/log/grout/app.log
+grcli -f /usr/local/bin/example-cnf/run/grout.init -s /usr/local/bin/example-cnf/run/grout.sock 2>&1 | tee /var/log/grout/app.log
 ```
 
 To deploy that config, we use the `grcli` command. If using `-f` argument, we will run all the commands that are defined in the file. If just using `grcli`, we'll open a CLI session with Grout and we can start interacting with the service. And also, we can use `grcli` followed by a Grout command to perform a particular action.
+
+We use `-s` argument to refer to a specific location of the Grout socket API file.
 
 For example, we can print statistics in the following way:
 
 ```
 # clear statistics
-$ sudo grcli clear stats
+$ sudo grcli -s /usr/local/bin/example-cnf/run/grout.sock clear stats
 
 # print statistics
-$ sudo grcli show stats software
+$ sudo grcli -s /usr/local/bin/example-cnf/run/grout.sock show stats software
 NODE                            CALLS  PACKETS  PKTS/CALL  CYCLES/CALL     CYCLES/PKT
 port_rx                  109805489408     2104        0.0         49.2   2567088141.0
 control_input            109805489408       39        0.0         22.6  63637321574.4
@@ -92,7 +94,7 @@ Also, you can trace the traffic received by Grout with the following configurati
 
 ```
 # enter in grout CLI
-$ grcli
+$ grcli -s /usr/local/bin/example-cnf/run/grout.sock
 grout# set trace all
 
 # if you get the latest N traces of traffic managed by Grout, you

--- a/grout-container-app/cnfapp/scripts/grout-wrapper
+++ b/grout-container-app/cnfapp/scripts/grout-wrapper
@@ -55,11 +55,13 @@ cat $GROUT_CONF_FILE
 
 # Start Grout on background
 ## Since v0.9.1, no socket is required, it's created as an abstract socket, available as grout.sock
-## Leaving it here just in case it's needed in the future
-#GROUT_SOCKET_FILE="/usr/local/bin/example-cnf/run/grout.sock"
+## However, on v0.10.2, there are permission issues because the socket is located on /run/grout.sock,
+## since we normally use a read-only filesystem, there are problems when creating it.
+## Switching to the usage of a custom grout.sock file instead, to better control it.
+GROUT_SOCKET_FILE="/usr/local/bin/example-cnf/run/grout.sock"
 echo "Starting Grout"
-#sudo grout -v -s $GROUT_SOCKET_FILE &
-sudo grout -v &
+sudo grout -v -s $GROUT_SOCKET_FILE &
+#sudo grout -v &
 
 # Wait a couple of seconds, so that we ensure Grout is running before starting configuring it
 sleep 5
@@ -67,7 +69,7 @@ sleep 5
 echo "Building Grout config script"
 # Build script to apply Grout configuration
 RUN="/usr/local/bin/example-cnf/run/config-grout"
-CMD="grcli -f $GROUT_CONF_FILE"
+CMD="grcli -f $GROUT_CONF_FILE -s $GROUT_SOCKET_FILE"
 CMD="${CMD} 2>&1 | tee $GROUT_LOG_FILE"
 echo "${CMD}" > $RUN
 chmod +x "$RUN"
@@ -88,7 +90,7 @@ if [[ $RUN_DEPLOYMENT == "1" ]]; then
     sudo /usr/local/bin/example-cnf/run/config-grout
 
     # Clear statistics
-    sudo grcli clear stats
+    sudo grcli -s $GROUT_SOCKET_FILE clear stats
 
     # Print statistics every $STAT_PERIOD seconds
     set +ex
@@ -97,7 +99,7 @@ if [[ $RUN_DEPLOYMENT == "1" ]]; then
         echo "*******************************************" 2>&1 | tee -a $GROUT_LOG_FILE
         date 2>&1 | tee -a $GROUT_LOG_FILE
         echo "*******************************************" 2>&1 | tee -a $GROUT_LOG_FILE
-        sudo grcli show stats software 2>&1 | tee -a $GROUT_LOG_FILE
+        sudo grcli -s $GROUT_SOCKET_FILE show stats software 2>&1 | tee -a $GROUT_LOG_FILE
         echo "" 2>&1 | tee -a $GROUT_LOG_FILE
         sleep $STATS_PERIOD
     done

--- a/utils/support-images/ubi9-base-grout/Dockerfile
+++ b/utils/support-images/ubi9-base-grout/Dockerfile
@@ -8,9 +8,12 @@ RUN dnf install -y \
 RUN dnf install -y \
     libibverbs \
     logrotate \
-    python3 \
+    python39 \
+    python3-pip \
     numactl \
     rdma-core \
     tcpdump \
     sudo \
     && dnf clean all
+
+RUN pip3 install kubernetes


### PR DESCRIPTION
- Move to Grout v0.10.2
- Made some changes in the base image, to be able to use it in a separate grout-test deployment
- Resume the usage of a custom grout socket file, since the current one is hitting issues with read-only filesystem

- [x] Test with `dci-pipeline-check https://github.com/openshift-kni/example-cnf/pull/123 -p mno_baremetal /var/lib/dci-openshift-agent/clusterconfigs-cluster1/kubeconfig example-cnf example-cnf:ansible_extravars=dci_teardown_on_success:true example-cnf:ansible_extravars=dci_teardown_on_failure:true example-cnf:ansible_extravars=example_cnf_cnfapp_name:grout example-cnf:ansible_extravars=check_workload_api:false example-cnf:ansible_extravars=do_certsuite:false example-cnf:ansible_extravars=certify_operators:false example-cnf:ansible_extravars=tests_to_verify:[]` - https://www.distributed-ci.io/jobs/2e3d5602-6c5b-4bf3-a072-4bb44c2efc22/jobStates