### PR TITLE
Software updates: operator-sdk, grout, go-toolset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DIRS            := trex-container-app testpmd-container-app grout-container-app trex-operator testpmd-operator grout-operator nfv-example-cnf-index
 
-OPERATOR_SDK_VER:= 1.41.1
+OPERATOR_SDK_VER:= 1.42.2
 
 # Print the possible targets and a short description
 .PHONY: targets

--- a/grout-container-app/Makefile
+++ b/grout-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.5
+VERSION         ?= 0.2.6
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/grout-container-app/build.sh
+++ b/grout-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.5"}
+TAG=${TAG:-"v0.2.6"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/grout-container-app/cnfapp/Dockerfile
+++ b/grout-container-app/cnfapp/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 
 ## grout image
-FROM quay.io/rh-nfv-int/ubi9-base-grout:v0.0.1
+FROM quay.io/rh-nfv-int/ubi10-base-grout:v0.0.1
 
 LABEL name="NFV Example CNF Grout Application" \
       maintainer="telcoci" \

--- a/grout-container-app/cnfapp/Dockerfile
+++ b/grout-container-app/cnfapp/Dockerfile
@@ -1,5 +1,5 @@
 ## Image to build webserver
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as build
 
 WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
@@ -12,14 +12,14 @@ FROM quay.io/rh-nfv-int/ubi9-base-grout:v0.0.1
 LABEL name="NFV Example CNF Grout Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.5" \
-      release="v0.2.5" \
+      version="v0.2.6" \
+      release="v0.2.6" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 
 COPY licenses /licenses
 
-ENV GROUT_VER v0.14.3
+ENV GROUT_VER v0.15.0
 ENV GROUT_RPM https://github.com/DPDK/grout/releases/download/${GROUT_VER}/grout.x86_64.rpm
 
 # check latest release from https://github.com/DPDK/grout/releases

--- a/grout-operator/CHANGELOG.md
+++ b/grout-operator/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] -
+## [0.2.4] - 2026-04-16
+
+- Updated Operator SDK to v1.42.2
+- Updated Ansible operator base image and plugin binary to v1.42.2
 
 ## [0.2.3] - 2025-10-27
 

--- a/grout-operator/CHANGELOG.md
+++ b/grout-operator/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.4] - 2026-04-16
+## [0.2.4] - 2026-04-17
 
 - Updated Operator SDK to v1.42.2
 - Updated Ansible operator base image and plugin binary to v1.42.2
+- Update grout-app deployment to match requirements for Grout v0.15.0
 
 ## [0.2.3] - 2025-10-27
 

--- a/grout-operator/Dockerfile
+++ b/grout-operator/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/operator-framework/ansible-operator:v1.39.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 LABEL name="NFV Example CNF Application Operator" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.3" \
-      release="v0.2.3" \
+      version="v0.2.4" \
+      release="v0.2.4" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/grout-operator/Makefile
+++ b/grout-operator/Makefile
@@ -3,11 +3,11 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION := 0.2.3
+VERSION := 0.2.4
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VER            ?= 1.41.1
+OPERATOR_SDK_VER            ?= 1.42.2
 
 # Other custom variables
 SHELL                       := /bin/bash
@@ -22,7 +22,7 @@ CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := grout-operator
 KUSTOMIZE_VER               := 5.6.0
 OPM_VER                     := 1.55.0
-ANSIBLE_OPERATOR_PLUGIN_VER := 1.39.0
+ANSIBLE_OPERATOR_PLUGIN_VER := 1.42.2
 # GROUT_VER determines the DPDK version to use
 GROUT_VER                 ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[grout-container-app]}"')
 

--- a/grout-operator/config/scorecard/patches/basic.config.yaml
+++ b/grout-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/grout-operator/config/scorecard/patches/olm.config.yaml
+++ b/grout-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/grout-operator/roles/grout/templates/deployment.yml
+++ b/grout-operator/roles/grout/templates/deployment.yml
@@ -103,6 +103,9 @@ spec:
           mountPath: /var/run/dpdk
         - name: tmp
           mountPath: /tmp
+        - name: tun
+          mountPath: /dev/net/tun
+          readOnly: true
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -165,3 +168,7 @@ spec:
         emptyDir: {}
       - name: tmp
         emptyDir: {}
+      - name: tun
+        hostPath:
+          path: /dev/net/tun
+          type: CharDevice

--- a/grout-operator/roles/grout/templates/deployment.yml
+++ b/grout-operator/roles/grout/templates/deployment.yml
@@ -76,6 +76,8 @@ spec:
 {% else %}
           capabilities:
             add: ["IPC_LOCK", "NET_ADMIN", "AUDIT_WRITE"]
+          seLinuxOptions:
+            type: spc_t
 {% endif %}
         resources:
           limits:
@@ -105,7 +107,6 @@ spec:
           mountPath: /tmp
         - name: tun
           mountPath: /dev/net/tun
-          readOnly: true
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.30] - 2026-04-16
+## [0.2.30] - 2026-04-17
 
 - Updated Operator SDK to v1.42.2
 - Updated Ansible operator base image and plugin binary to v1.42.2

--- a/testpmd-operator/CHANGELOG.md
+++ b/testpmd-operator/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] -
+## [0.2.30] - 2026-04-16
+
+- Updated Operator SDK to v1.42.2
+- Updated Ansible operator base image and plugin binary to v1.42.2
 
 ## [0.2.29] - 2025-10-27
 

--- a/testpmd-operator/Dockerfile
+++ b/testpmd-operator/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/operator-framework/ansible-operator:v1.39.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 LABEL name="NFV Example CNF Application Operator" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.29" \
-      release="v0.2.29" \
+      version="v0.2.30" \
+      release="v0.2.30" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -3,11 +3,11 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION := 0.2.29
+VERSION := 0.2.30
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VER            ?= 1.41.1
+OPERATOR_SDK_VER            ?= 1.42.2
 
 # Other custom variables
 SHELL                       := /bin/bash
@@ -22,7 +22,7 @@ CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := testpmd-operator
 KUSTOMIZE_VER               := 5.6.0
 OPM_VER                     := 1.55.0
-ANSIBLE_OPERATOR_PLUGIN_VER := 1.39.0
+ANSIBLE_OPERATOR_PLUGIN_VER := 1.42.2
 # TESTPMD_VER determines the DPDK version to use
 TESTPMD_VER                 ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[testpmd-container-app]}"')
 

--- a/testpmd-operator/config/scorecard/patches/basic.config.yaml
+++ b/testpmd-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/testpmd-operator/config/scorecard/patches/olm.config.yaml
+++ b/testpmd-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/trex-operator/CHANGELOG.md
+++ b/trex-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.32] - 2026-04-16
+## [0.2.32] - 2026-04-17
 
 - Updated Operator SDK to v1.42.2
 - Updated Ansible operator base image and plugin binary to v1.42.2

--- a/trex-operator/CHANGELOG.md
+++ b/trex-operator/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] -
+## [0.2.32] - 2026-04-16
+
+- Updated Operator SDK to v1.42.2
+- Updated Ansible operator base image and plugin binary to v1.42.2
 
 ## [0.2.31] - 2025-10-27
 

--- a/trex-operator/Dockerfile
+++ b/trex-operator/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/operator-framework/ansible-operator:v1.39.0
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 LABEL name="NFV Example CNF TRex Operator" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.31" \
-      release="v0.2.31" \
+      version="v0.2.32" \
+      release="v0.2.32" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -3,11 +3,11 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.31
+VERSION ?= 0.2.32
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VER ?= 1.41.1
+OPERATOR_SDK_VER ?= 1.42.2
 
 # Other custom variables
 SHELL                       := /bin/bash
@@ -22,7 +22,7 @@ CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := trex-operator
 KUSTOMIZE_VER               := 5.6.0
 OPM_VER                     := 1.55.0
-ANSIBLE_OPERATOR_PLUGIN_VER := 1.39.0
+ANSIBLE_OPERATOR_PLUGIN_VER := 1.42.2
 TREX_VER                    ?= v$(shell bash -c '. ../versions.cfg; echo "$${VERSIONS[trex-container-app]}"')
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/trex-operator/config/scorecard/patches/basic.config.yaml
+++ b/trex-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/trex-operator/config/scorecard/patches/olm.config.yaml
+++ b/trex-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.41.1
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/utils/README.md
+++ b/utils/README.md
@@ -12,11 +12,11 @@ $ cd support-images
 $ podman build dpdk -f dpdk/Dockerfile -t "quay.io/rh-nfv-int/dpdk:v0.0.1"
 $ podman build ubi8-base-testpmd -f ubi8-base-testpmd/Dockerfile -t "quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1"
 $ podman build ubi8-base-trex -f ubi8-base-trex/Dockerfile -t "quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1"
-$ podman build ubi9-base-grout -f ubi9-base-grout/Dockerfile -t "quay.io/rh-nfv-int/ubi9-base-grout:v0.0.1"
+$ podman build ubi10-base-grout -f ubi10-base-grout/Dockerfile -t "quay.io/rh-nfv-int/ubi10-base-grout:v0.0.1"
 
 # push images (to quay.io/rh-nfv-int)
 $ podman push quay.io/rh-nfv-int/dpdk:v0.0.1
 $ podman push quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 $ podman push quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1
-$ podman push quay.io/rh-nfv-int/ubi9-base-grout:v0.0.1
+$ podman push quay.io/rh-nfv-int/ubi10-base-grout:v0.0.1
 ```

--- a/utils/required-annotations.yaml
+++ b/utils/required-annotations.yaml
@@ -7,4 +7,4 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: ">=0.2.3 <=0.2.31"
+    olm.skipRange: ">=0.2.4 <=0.2.32"

--- a/utils/support-images/ubi10-base-grout/Dockerfile
+++ b/utils/support-images/ubi10-base-grout/Dockerfile
@@ -1,14 +1,14 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi10/ubi:latest
 
 # Install EPEL from Fedora
 RUN dnf install -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 
 # Install other required packages for grout
 RUN dnf install -y \
     libibverbs \
     logrotate \
-    python39 \
+    python3 \
     python3-pip \
     numactl \
     rdma-core \


### PR DESCRIPTION
Bumps toolchain and dependency versions across the repo:

- Operator SDK 1.41.1 → 1.42.2 (root Makefile, all Ansible operators’ Makefiles, scorecard scorecard-test images)
- ansible-operator base image and plugin 1.39.0 → 1.42.2
- Grout in the container app (v0.14.3 → v0.15.0) with UBI9 go-toolset 1.24 → 1.25. Grout container app version is 0.2.5 → 0.2.6
  - Updated grout base image to ubi10, to be compliant with grout v0.15.0
  - /dev/net/tun directory needs to be imported in the container, and spc_t SELinux option is required for this (if not using privileged mode).
- operator image versions and changelogs are updated (grout-operator 0.2.4, testpmd-operator 0.2.30, trex-operator 0.2.32)
- utils/required-annotations.yaml olm.skipRange is adjusted for the new operator versions.

- [x] Privileged mode: https://www.distributed-ci.io/jobs/6b9af479-ba4a-4392-b272-b0cf9a21dff9/jobStates
- [x] Non-privileged mode: https://www.distributed-ci.io/jobs/ce3745d8-33e9-4b58-8f0e-342c5329f73c/jobStates

Assisted-by: Cursor