### PR TITLE
Hotfix to make Grout v0.15.0 compatible with failed certsuite tests

### DIFF
--- a/grout-operator/roles/grout/templates/deployment.yml
+++ b/grout-operator/roles/grout/templates/deployment.yml
@@ -107,6 +107,8 @@ spec:
           mountPath: /var/run/dpdk
         - name: tmp
           mountPath: /tmp
+        - name: tun
+          mountPath: /dev/net/tun
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -169,4 +171,5 @@ spec:
         emptyDir: {}
       - name: tmp
         emptyDir: {}
-
+      - name: tun
+        emptyDir: {}

--- a/grout-operator/roles/grout/templates/deployment.yml
+++ b/grout-operator/roles/grout/templates/deployment.yml
@@ -172,4 +172,6 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: tun
-        emptyDir: {}
+        hostPath:
+          path: /dev/net/tun
+          type: CharDevice

--- a/grout-operator/roles/grout/templates/deployment.yml
+++ b/grout-operator/roles/grout/templates/deployment.yml
@@ -63,6 +63,8 @@ spec:
         ports:
         - name: "http-probe"
           containerPort: 8095
+        - name: "tcp-gr-svc"
+          containerPort: 9111
         image: "{{ image_grout }}"
         imagePullPolicy: "{{ image_pull_policy }}"
         securityContext:
@@ -105,8 +107,6 @@ spec:
           mountPath: /var/run/dpdk
         - name: tmp
           mountPath: /tmp
-        - name: tun
-          mountPath: /dev/net/tun
         env:
         - name: NETWORK_NAME_LIST
           value: "{{ network_resources.keys()|list|join(',') }}"
@@ -169,7 +169,4 @@ spec:
         emptyDir: {}
       - name: tmp
         emptyDir: {}
-      - name: tun
-        hostPath:
-          path: /dev/net/tun
-          type: CharDevice
+


### PR DESCRIPTION
The current implementation of the Grout v0.15.0's integration in example-cnf is throwing two errors in certsuite tests:

- [access-control-pod-host-path](https://www.distributed-ci.io/jobs/10c13f0f-a5be-48a6-a5a4-630055a3030f/tests/7d054cf3-9980-4e3d-b6c0-44c7fd8b4972?testcase=access-control-pod-host-path) - hostPath attribute should not be used, but if not using privileged mode, we need to use it to be able to use the tun module from the OCP node. So, this cannot be changed.
- [networking-undeclared-container-ports-usage](https://www.distributed-ci.io/jobs/10c13f0f-a5be-48a6-a5a4-630055a3030f/tests/7d054cf3-9980-4e3d-b6c0-44c7fd8b4972?testcase=access-control-pod-host-path) - there's a new undeclared port in the grout-app pod, 9111

Making the changes to pass the second test.