### PR TITLE
Bump software versions - Grout, go-toolset

### DIFF
--- a/grout-container-app/Makefile
+++ b/grout-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.6
+VERSION         ?= 0.2.7
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/grout-container-app/build.sh
+++ b/grout-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.6"}
+TAG=${TAG:-"v0.2.7"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/grout-container-app/cnfapp/Dockerfile
+++ b/grout-container-app/cnfapp/Dockerfile
@@ -1,5 +1,5 @@
 ## Image to build webserver
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 as build
 
 WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
@@ -12,14 +12,14 @@ FROM quay.io/rh-nfv-int/ubi10-base-grout:v0.0.1
 LABEL name="NFV Example CNF Grout Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.6" \
-      release="v0.2.6" \
+      version="v0.2.7" \
+      release="v0.2.7" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 
 COPY licenses /licenses
 
-ENV GROUT_VER v0.15.0
+ENV GROUT_VER v0.16.0
 ENV GROUT_RPM https://github.com/DPDK/grout/releases/download/${GROUT_VER}/grout.x86_64.rpm
 
 # check latest release from https://github.com/DPDK/grout/releases

--- a/nfv-example-cnf-index/Makefile
+++ b/nfv-example-cnf-index/Makefile
@@ -5,6 +5,7 @@ TAG            := $(VERSION)-$(DATE).$(SHA)
 REGISTRY       ?= quay.io
 ORG            ?= rh-nfv-int
 CONTAINER_CLI  ?= podman
+export CONTAINERS_REGISTRIES_CONF ?= /dev/null
 CLUSTER_CLI    ?= oc
 INDEX_NAME     := nfv-example-cnf-catalog
 INDEX_IMG      ?= $(REGISTRY)/$(ORG)/$(INDEX_NAME):v$(TAG)

--- a/testpmd-container-app/Makefile
+++ b/testpmd-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.19
+VERSION         ?= 0.2.20
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/testpmd-container-app/build.sh
+++ b/testpmd-container-app/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=${TAG:-"v0.2.19"}
+TAG=${TAG:-"v0.2.20"}
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/testpmd-container-app/cnfapp/Dockerfile
+++ b/testpmd-container-app/cnfapp/Dockerfile
@@ -2,7 +2,7 @@
 FROM quay.io/rh-nfv-int/dpdk:v0.0.1 as build
 
 ## Image to build webserver
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as build2
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 as build2
 
 WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
@@ -15,8 +15,8 @@ FROM quay.io/rh-nfv-int/ubi8-base-testpmd:v0.0.1
 LABEL name="NFV Example CNF Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.19" \
-      release="v0.2.19" \
+      version="v0.2.20" \
+      release="v0.2.20" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/trex-container-app/Makefile
+++ b/trex-container-app/Makefile
@@ -2,7 +2,7 @@ SHELL           := /bin/bash
 
 DATE            ?= $(shell date --utc +%Y%m%d%H%M)
 SHA             ?= $(shell git rev-parse --short HEAD)
-VERSION         ?= 0.2.20
+VERSION         ?= 0.2.21
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int
 CONTAINER_CLI   ?= podman

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -1,17 +1,17 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 as build
 
 WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 
-FROM registry.access.redhat.com/ubi8/python-311:latest
+FROM registry.access.redhat.com/ubi9/python-314:latest
 
 LABEL name="NFV Example TRexApp Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.19" \
-      release="v0.2.19" \
+      version="v0.2.21" \
+      release="v0.2.21" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 

--- a/trex-container-app/app/Dockerfile
+++ b/trex-container-app/app/Dockerfile
@@ -5,7 +5,7 @@ COPY utils/webserver.go .
 RUN go mod init webserver.go
 RUN GOOS=linux CGO_ENABLED=0 go build -a -o webserver .
 
-FROM registry.access.redhat.com/ubi9/python-314:latest
+FROM registry.access.redhat.com/ubi8/python-311:latest
 
 LABEL name="NFV Example TRexApp Application" \
       maintainer="telcoci" \

--- a/trex-container-app/build.sh
+++ b/trex-container-app/build.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
-TAG="${TAG:-v0.2.20}"
+TAG="${TAG:-v0.2.21}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/trex-container-app/server/Dockerfile
+++ b/trex-container-app/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 as build
 
 WORKDIR /opt/app-root/src
 COPY utils/webserver.go .
@@ -11,8 +11,8 @@ FROM quay.io/rh-nfv-int/ubi8-base-trex:v0.0.1
 LABEL name="NFV Example TRexServer Application" \
       maintainer="telcoci" \
       vendor="fredco" \
-      version="v0.2.20" \
-      release="v0.2.20" \
+      version="v0.2.21" \
+      release="v0.2.21" \
       summary="An example CNF for platform validation" \
       description="An example CNF for platform validation"
 


### PR DESCRIPTION
**grout-container-app (v0.2.6 → v0.2.7)**
- Grout: v0.15.0 → v0.16.0
- Go build stage: ubi9/go-toolset:1.25 → ubi10/go-toolset:1.26
- Updated: cnfapp/Dockerfile, Makefile, build.sh

**trex-container-app**
_app (v0.2.19 → v0.2.21) - advancing two versions to align with server:
- Go build stage: ubi9/go-toolset:1.24 → ubi10/go-toolset:1.26

_server (v0.2.20 → v0.2.21):_
- Go build stage: ubi9/go-toolset:1.24 → ubi10/go-toolset:1.26

- Updated: app/Dockerfile, server/Dockerfile, Makefile (0.2.21), build.sh (v0.2.21)

**testpmd-container-app (v0.2.19 → v0.2.20)**
- Go build stage: ubi9/go-toolset:1.24 → ubi10/go-toolset:1.26
- Updated: cnfapp/Dockerfile, Makefile, build.sh

(+ Bypass v1 registries.conf when building the catalog index)

- [x] example-cnf with grout - https://www.distributed-ci.io/jobs/5b0400b2-de51-44ed-8ed2-fa9b58566587/jobStates?sort=date
- [x] example-cnf with testpmd - https://www.distributed-ci.io/jobs/edab5254-727e-4c86-a60f-22832e630338/jobStates?sort=date