### PR TITLE
Fix skopeo inspect failures on GitHub Actions runners

### DIFF
--- a/grout-operator/Makefile
+++ b/grout-operator/Makefile
@@ -18,6 +18,7 @@ REGISTRY                    ?= quay.io
 ORG                         ?= rh-nfv-int
 DEFAULT_CHANNEL             ?= alpha
 CONTAINER_CLI               ?= podman
+export CONTAINERS_REGISTRIES_CONF ?= /dev/null
 CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := grout-operator
 KUSTOMIZE_VER               := 5.6.0
@@ -138,7 +139,7 @@ undeploy:
 # Ensure proper digests for grout-container-app-cnfapp
 .PHONY: ensure_digests
 ensure_digests:
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/grout-container-app-cnfapp:$(GROUT_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/grout-container-app-cnfapp@.*/grout-container-app-cnfapp@$${DIGEST}\"   # $(GROUT_VER)/" roles/grout/defaults/main.yml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/grout-container-app-cnfapp:$(GROUT_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/grout-container-app-cnfapp@.*/grout-container-app-cnfapp@$${DIGEST}\"   # $(GROUT_VER)/" roles/grout/defaults/main.yml
 
 # Build the operator image
 .PHONY: operator-build
@@ -241,9 +242,9 @@ bundle: kustomize operator-sdk yq ## Generate bundle manifests and metadata, the
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item )' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml ../utils/required-annotations.yaml > tmp_csv.yaml
 	mv tmp_csv.yaml bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
-	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && [ -n "$${DIGEST}" ] && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://$(IMG) | jq -r '.Digest') && [ -n "$${DIGEST}" ] && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/grout-container-app-cnfapp:$(GROUT_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/grout-container-app-cnfapp@.*/grout-container-app-cnfapp@$${DIGEST}\"   # $(GROUT_VER)/" relatedImages.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/grout-container-app-cnfapp:$(GROUT_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/grout-container-app-cnfapp@.*/grout-container-app-cnfapp@$${DIGEST}\"   # $(GROUT_VER)/" relatedImages.yaml
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/nfv-example-cnf-index/Makefile
+++ b/nfv-example-cnf-index/Makefile
@@ -52,7 +52,7 @@ index-build: opm
 		operator_bundle=$${OPERATOR/:*}-bundle ;\
 		operator_version=$${OPERATOR/*:} ;\
 		operator_name=$${OPERATOR/:*} ;\
-		operator_manifest=$$(skopeo inspect docker://$(REGISTRY)/$(ORG)/$${operator_bundle}:$${operator_version}) ;\
+		operator_manifest=$$(skopeo inspect --no-tags docker://$(REGISTRY)/$(ORG)/$${operator_bundle}:$${operator_version}) ;\
 		operator_digest=$$(jq -r '.Digest' <<< $${operator_manifest}) ;\
 		bundle_digest=$(REGISTRY)/$(ORG)/$${operator_bundle}@$${operator_digest} ;\
 		echo "operator=$${operator_name} operator_version=$${operator_version} operator_digest=$${operator_digest}" ;\

--- a/testpmd-operator/Makefile
+++ b/testpmd-operator/Makefile
@@ -18,6 +18,7 @@ REGISTRY                    ?= quay.io
 ORG                         ?= rh-nfv-int
 DEFAULT_CHANNEL             ?= alpha
 CONTAINER_CLI               ?= podman
+export CONTAINERS_REGISTRIES_CONF ?= /dev/null
 CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := testpmd-operator
 KUSTOMIZE_VER               := 5.6.0
@@ -138,7 +139,7 @@ undeploy:
 # Ensure proper digests for testpmd-container-app-cnfapp
 .PHONY: ensure_digests
 ensure_digests:
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-cnfapp:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-cnfapp@.*/testpmd-container-app-cnfapp@$${DIGEST}\"   # $(TESTPMD_VER)/" roles/testpmd/defaults/main.yml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/testpmd-container-app-cnfapp:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-cnfapp@.*/testpmd-container-app-cnfapp@$${DIGEST}\"   # $(TESTPMD_VER)/" roles/testpmd/defaults/main.yml
 
 # Build the operator image
 .PHONY: operator-build
@@ -241,9 +242,9 @@ bundle: kustomize operator-sdk yq ## Generate bundle manifests and metadata, the
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item )' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml ../utils/required-annotations.yaml > tmp_csv.yaml
 	mv tmp_csv.yaml bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
-	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && [ -n "$${DIGEST}" ] && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://$(IMG) | jq -r '.Digest') && [ -n "$${DIGEST}" ] && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/testpmd-container-app-cnfapp:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-cnfapp@.*/testpmd-container-app-cnfapp@$${DIGEST}\"   # $(TESTPMD_VER)/" relatedImages.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/testpmd-container-app-cnfapp:$(TESTPMD_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/testpmd-container-app-cnfapp@.*/testpmd-container-app-cnfapp@$${DIGEST}\"   # $(TESTPMD_VER)/" relatedImages.yaml
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/trex-operator/Makefile
+++ b/trex-operator/Makefile
@@ -18,6 +18,7 @@ REGISTRY                    ?= quay.io
 ORG                         ?= rh-nfv-int
 DEFAULT_CHANNEL             ?= alpha
 CONTAINER_CLI               ?= podman
+export CONTAINERS_REGISTRIES_CONF ?= /dev/null
 CLUSTER_CLI                 ?= oc
 OPERATOR_NAME               := trex-operator
 KUSTOMIZE_VER               := 5.6.0
@@ -136,8 +137,8 @@ undeploy:
 # Ensure proper digests for trex-container-app and trex-container-server
 .PHONY: ensure_digests
 ensure_digests:
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/trex-container-app:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-app@.*/trex-container-app@$${DIGEST}\"   # $(TREX_VER)/" roles/trexapp/defaults/main.yml
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/trex-container-server:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-server@.*/trex-container-server@$${DIGEST}\"   # $(TREX_VER)/" roles/trexconfig/defaults/main.yml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/trex-container-app:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-app@.*/trex-container-app@$${DIGEST}\"   # $(TREX_VER)/" roles/trexapp/defaults/main.yml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/trex-container-server:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-server@.*/trex-container-server@$${DIGEST}\"   # $(TREX_VER)/" roles/trexconfig/defaults/main.yml
 
 # Build the operator image
 .PHONY: operator-build
@@ -242,10 +243,10 @@ bundle: kustomize operator-sdk yq
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item )' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml ../utils/required-annotations.yaml > tmp_csv.yaml
 	mv tmp_csv.yaml bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml	
-	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://$(IMG) | jq -r '.Digest') && sed -i -e 's/\(\s*image: .*\):v'$(TAG)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.12"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/trex-container-server:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-server@.*/trex-container-server@$${DIGEST}\"   # $(TREX_VER)/" relatedImages.yaml
-	DIGEST=$$(skopeo inspect docker://quay.io/rh-nfv-int/trex-container-app:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-app@.*/trex-container-app@$${DIGEST}\"   # $(TREX_VER)/" relatedImages.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/trex-container-server:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-server@.*/trex-container-server@$${DIGEST}\"   # $(TREX_VER)/" relatedImages.yaml
+	DIGEST=$$(skopeo inspect --no-tags docker://quay.io/rh-nfv-int/trex-container-app:$(TREX_VER)|jq -r .Digest) && [ -n "$${DIGEST}" ] && sed -i -e "s/trex-container-app@.*/trex-container-app@$${DIGEST}\"   # $(TREX_VER)/" relatedImages.yaml
 	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 	echo "bundle image=$(IMG)"


### PR DESCRIPTION
# Summary

- This intends to fix the issues found in the build_all Github action, that is currently [failing](https://github.com/openshift-kni/example-cnf/actions/runs/28242097791/job/83946135052) for merged PRs.
- Add `export CONTAINERS_REGISTRIES_CONF ?= /dev/null` to the trex, testpmd, and grout operator Makefiles so skopeo uses built-in defaults on GitHub Actions runners (same approach as nfv-example-cnf-index).
- Use `skopeo inspect --no-tags` everywhere we only need the image digest, since tag listing was triggering `Error determining repository tags: can't talk to a V1 container registry` during bundle generation.

# Context

The publish workflow was failing in trex-operator at the bundle target when resolving digests for related images. The operator image inspect succeeded, but the next call for trex-container-server failed. The Makefiles only need .Digest, not RepoTags, so listing all repository tags is unnecessary and was hitting a flaky/incompatible code path on ubuntu-latest runners.

Test-Hints: no-check