### PR TITLE
Force the creation of DCI components on a weekly basis

### DIFF
--- a/.github/workflows/dci_component_weekly.yaml
+++ b/.github/workflows/dci_component_weekly.yaml
@@ -1,0 +1,61 @@
+---
+name: Create DCI components for Example CNF
+
+on:
+  schedule:
+    - cron: "0 20 * * 5" # Fridays at 20:00 UTC
+  workflow_dispatch:
+
+env:
+  QUAY_REGISTRY: quay.io
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish_dci_component:
+    runs-on: ubuntu-latest
+    steps:
+      # This tag is used to build the DCI component, as both the tag and the component version match
+      - name: Get latest Quay tag from nfv-example-cnf-catalog
+        id: quay
+        run: |
+          # Build tags look like v0.3.10-202606290619.18d0463; skip floating aliases (e.g. v0.3.10).
+          version=$(
+            curl -fsSL \
+              "https://quay.io/api/v1/repository/rh-nfv-int/nfv-example-cnf-catalog/tag/?onlyActiveTags=true&limit=100" |
+            jq -r '[.tags[] | select(.name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+\\.[0-9a-f]+$"))] | sort_by(.start_ts) | reverse | .[0].name'
+          )
+          if [[ -z "${version}" || "${version}" == "null" ]]; then
+            echo "Failed to resolve latest build tag from Quay" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Using Quay tag: ${version}"
+
+      # Create the DCI component for all OCP topics.
+      # If the component is already created, nothing will be done.
+      # This is done to cover these two cases:
+      # - A new DCI topic is released and no nfv-example-cnf-index component is created yet.
+      # - After merging a PR, the push action failed and no DCI component was created.
+      - name: Create DCI components
+        id: dci
+        uses: dci-labs/dci-component@071020fc9ded27153c7bc1bfef3aac136bba52f6  # v1.7.0
+        with:
+          dciClientId: ${{ secrets.DCI_CLIENT_ID }}
+          dciApiSecret: ${{ secrets.DCI_API_SECRET }}
+          dciTopics: 'all-OCP'
+          componentName: nfv-example-cnf-index
+          componentVersion: ${{ steps.quay.outputs.version }}
+          componentData: '{"url":"${{ env.QUAY_REGISTRY }}/rh-nfv-int/nfv-example-cnf-catalog"}'
+          componentRelease: ga
+
+      - name: Results
+        run: |
+          echo "## DCI components" >> ${GITHUB_STEP_SUMMARY}
+          echo "" >> ${GITHUB_STEP_SUMMARY}
+          echo "\`\`\`JSON" >> ${GITHUB_STEP_SUMMARY}
+          <<<'${{ steps.dci.outputs.components }}' jq '.[] | del(.component.jobs)' | grep -v team_id >> ${GITHUB_STEP_SUMMARY}
+          echo "\`\`\`" >> ${GITHUB_STEP_SUMMARY}
+          echo "" >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
- Create the DCI component for all OCP topics on a weely basis.
  - The version used is retrieved from the latest image available in quay.io for the nfv-example-cnf-catalog.
- If the component is already created, nothing will be done.
- This is done to cover these two cases:
  - A new DCI topic is released and no nfv-example-cnf-index component is created yet.
  - After merging a PR, the push action failed and no DCI component was created.

- [x] Manual validation of the check (no new DCI component is created because they're already in place): https://github.com/openshift-kni/example-cnf/actions/runs/29261765910

Test-Hints: no-check